### PR TITLE
Improve docs and algorithm overview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Documentation Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --with docs
+      - name: Build documentation
+        run: poetry run sphinx-build -W -b html docs/source docs/build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: documentation
+          path: docs/build/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,10 +4,22 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_create_environment:
+      - pip install poetry
+    post_install:
+      - poetry config virtualenvs.create false
+      - poetry install --with docs
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
 
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: false
+
+formats:
+  - pdf
+  - epub

--- a/README.md
+++ b/README.md
@@ -1,180 +1,97 @@
 # gen_surv
 
-![Coverage](https://codecov.io/gh/DiogoRibeiro7/genSurvPy/branch/main/graph/badge.svg)
-[![Docs](https://readthedocs.org/projects/gensurvpy/badge/?version=stable)](https://gensurvpy.readthedocs.io/en/stable/)
-![PyPI](https://img.shields.io/pypi/v/gen_surv)
-![Tests](https://github.com/DiogoRibeiro7/genSurvPy/actions/workflows/test.yml/badge.svg)
-![Python](https://img.shields.io/pypi/pyversions/gen_surv)
+[![Coverage](https://codecov.io/gh/DiogoRibeiro7/genSurvPy/branch/main/graph/badge.svg)](https://app.codecov.io/gh/DiogoRibeiro7/genSurvPy)
+[![Docs](https://readthedocs.org/projects/gensurvpy/badge/?version=latest)](https://gensurvpy.readthedocs.io/en/latest/)
+[![PyPI](https://img.shields.io/pypi/v/gen_surv)](https://pypi.org/project/gen-surv/)
+[![Tests](https://github.com/DiogoRibeiro7/genSurvPy/actions/workflows/test.yml/badge.svg)](https://github.com/DiogoRibeiro7/genSurvPy/actions/workflows/test.yml)
+[![Python](https://img.shields.io/pypi/pyversions/gen_surv)](https://pypi.org/project/gen-surv/)
 
-
-**gen_surv** is a Python package for simulating survival data under a variety of models, inspired by the R package [`genSurv`](https://cran.r-project.org/package=genSurv). It supports data generation for:
-
-- Cox Proportional Hazards Models (CPHM)
-- Continuous-Time Markov Models (CMM)
-- Time-Dependent Covariate Models (TDCM)
-- Time-Homogeneous Hidden Markov Models (THMM)
+**gen_surv** is a Python package for simulating survival data under a variety of statistical models. It is inspired by the R package [genSurv](https://cran.r-project.org/package=genSurv) and provides a unified interface for generating realistic survival datasets.
 
 ---
 
-## 📦 Installation
+## Features
 
-```bash
-poetry install
-```
-This package requires **Python 3.10** or later.
-## ✨ Features
-
-- Consistent interface across models
-- Censoring support (`uniform` or `exponential`)
-- Easy integration with `pandas` and `NumPy`
-- Suitable for benchmarking survival algorithms and teaching
-- Accelerated Failure Time (Log-Normal) model generator
+- Cox proportional hazards model (CPHM)
+- Accelerated failure time models (log-normal, log-logistic)
+- Continuous-time multi-state Markov model (CMM)
+- Time-dependent covariate model (TDCM)
+- Time-homogeneous hidden Markov model (THMM)
 - Mixture cure and piecewise exponential models
 - Competing risks generators (constant and Weibull hazards)
-- Command-line interface powered by `Typer`
-- Export utilities for CSV, JSON, and Feather formats
+- Command-line interface and export utilities
 
-## 🧪 Example
+## Installation
+
+Install the latest release from PyPI:
+
+```bash
+pip install gen-surv
+```
+
+To develop locally with all extras:
+
+```bash
+git clone https://github.com/DiogoRibeiro7/genSurvPy.git
+cd genSurvPy
+poetry install
+```
+
+## Quick Example
 
 ```python
 from gen_surv import generate
 
-# CPHM
-generate(model="cphm", n=100, model_cens="uniform", cens_par=1.0, beta=0.5, covariate_range=2.0)
-
-# AFT Log-Normal
-generate(model="aft_ln", n=100, beta=[0.5, -0.3], sigma=1.0, model_cens="exponential", cens_par=3.0)
-
-# CMM
-generate(model="cmm", n=100, model_cens="exponential", cens_par=2.0,
-         qmat=[[0, 0.1], [0.05, 0]], p0=[1.0, 0.0])
-
-# TDCM
-generate(model="tdcm", n=100, dist="weibull", corr=0.5,
-         dist_par=[1, 2, 1, 2], model_cens="uniform", cens_par=1.0,
-         beta=[0.1, 0.2, 0.3], lam=1.0)
-
-# THMM
-generate(model="thmm", n=100, qmat=[[0, 0.2, 0], [0.1, 0, 0.1], [0, 0.3, 0]],
-         emission_pars={"mu": [0.0, 1.0, 2.0], "sigma": [0.5, 0.5, 0.5]},
-         p0=[1.0, 0.0, 0.0], model_cens="exponential", cens_par=3.0)
-
-# Mixture Cure
-generate(model="mixture_cure", n=100, cure_fraction=0.3, seed=42)
-
-# Piecewise Exponential
-generate(
-    model="piecewise_exponential",
-    n=100,
-    breakpoints=[1.0, 3.0],
-    hazard_rates=[0.2, 0.5, 1.0],
-    seed=0
-)
+# basic Cox proportional hazards data
+sim = generate(model="cphm", n=100, beta=0.5, covar=2.0,
+               model_cens="uniform", cens_par=1.0)
 ```
 
-## ⌨️ Command-Line Usage
+See the [usage guide](docs/source/getting_started.md) for more examples.
 
-Install the package and use ``python -m gen_surv`` to generate datasets without
-writing Python code:
+## Supported Models
+
+| Model                | Description                             |
+|----------------------|-----------------------------------------|
+| **CPHM**             | Cox proportional hazards                |
+| **AFT**              | Accelerated failure time (log-normal, log-logistic) |
+| **CMM**              | Continuous-time multi-state Markov      |
+| **TDCM**             | Time-dependent covariates                |
+| **THMM**             | Time-homogeneous hidden Markov          |
+| **Competing Risks**  | Multiple event types with cause-specific hazards |
+| **Mixture Cure**     | Models long-term survivors              |
+| **Piecewise Exponential** | Flexible baseline hazard via intervals |
+
+More details on each algorithm are available in the [Algorithms](docs/source/algorithms.md) page and the [theory guide](docs/source/theory.md).
+
+## Command-Line Usage
+
+Datasets can be generated without writing Python code:
 
 ```bash
-python -m gen_surv dataset aft_ln --n 100 > data.csv
+python -m gen_surv dataset cphm --n 1000 -o survival.csv
 ```
 
-## 🔧 API Overview
+## Documentation
 
-| Function | Description |
-|----------|-------------|
-| `generate()` | Unified interface that calls any generator |
-| `gen_cphm()` | Cox Proportional Hazards Model |
-| `gen_cmm()`  | Continuous-Time Multi-State Markov Model |
-| `gen_tdcm()` | Time-Dependent Covariate Model |
-| `gen_thmm()` | Time-Homogeneous Markov Model |
-| `gen_aft_log_normal()` | Accelerated Failure Time Log-Normal |
-| `gen_aft_log_logistic()` | AFT model with log-logistic baseline |
-| `gen_competing_risks()` | Competing risks with constant hazards |
-| `gen_competing_risks_weibull()` | Competing risks with Weibull hazards |
-| `gen_mixture_cure()` | Mixture cure model |
-| `cure_fraction_estimate()` | Estimate cure fraction |
-| `gen_piecewise_exponential()` | Piecewise exponential model |
-| `sample_bivariate_distribution()` | Sample correlated Weibull or exponential times |
-| `runifcens()` | Generate uniform censoring times |
-| `rexpocens()` | Generate exponential censoring times |
-| `export_dataset()` | Save a dataset to CSV, JSON or Feather |
+Full documentation is hosted on [Read the Docs](https://gensurvpy.readthedocs.io/en/latest/). It includes installation instructions, tutorials, API references and a bibliography.
 
-
-```text
-genSurvPy/
-├── gen_surv/             # Pacote principal
-│   ├── __main__.py       # Interface CLI via python -m
-│   ├── cphm.py
-│   ├── cmm.py
-│   ├── tdcm.py
-│   ├── thmm.py
-│   ├── censoring.py
-│   ├── bivariate.py
-│   ├── validate.py
-│   └── interface.py
-├── tests/                # Testes automatizados
-│   ├── test_cphm.py
-│   ├── test_cmm.py
-│   ├── test_tdcm.py
-│   ├── test_thmm.py
-├── examples/             # Exemplos de uso
-│   ├── run_aft.py
-│   ├── run_cmm.py
-│   ├── run_cphm.py
-│   ├── run_tdcm.py
-│   └── run_thmm.py
-├── docs/                 # Documentação Sphinx
-│   ├── source/
-│   └── ...
-├── scripts/              # Utilidades diversas
-│   └── check_version_match.py
-├── tasks.py              # Tarefas automatizadas com Invoke
-├── TODO.md               # Roadmap de desenvolvimento
-├── pyproject.toml        # Configurado com Poetry
-├── README.md
-├── LICENCE
-└── .gitignore
-```
-
-## 🧠 License
-
-MIT License. See [LICENCE](LICENCE) for details.
-
-
-## 🔖 Release Process
-
-This project uses Git tags to manage releases. A GitHub Actions workflow
-(`version-check.yml`) verifies that the version declared in `pyproject.toml`
-matches the latest Git tag. If they diverge, the workflow fails and prompts a
-correction before merging. Run `python scripts/check_version_match.py` locally
-before creating a tag to catch issues early.
-
-## 🌟 Code of Conduct
-
-Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to learn about the
-expectations for participants in this project.
-
-## 🤝 Contributing
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up your environment, running tests, and submitting pull requests.
-
-## 🔧 Development Tasks
-
-Common project commands are defined in [`tasks.py`](tasks.py) and can be executed with [Invoke](https://www.pyinvoke.org/):
+To build the docs locally:
 
 ```bash
-poetry run inv -l  # list available tasks
-poetry run inv test  # run the test suite
+cd docs
+make html
 ```
 
-## 📑 Citation
+Open `build/html/index.html` in your browser to view the result.
 
-If you use **gen_surv** in your work, please cite it using the metadata in
-[`CITATION.cff`](CITATION.cff). Many reference managers can import this file
-directly.
+## License
+
+This project is licensed under the MIT License. See [LICENCE](LICENCE) for details.
+
+## Citation
+
+If you use **gen_surv** in your research, please cite the project using the metadata in [CITATION.cff](CITATION.cff).
 
 ## Author
 
@@ -183,3 +100,4 @@ directly.
 - ORCID: <https://orcid.org/0009-0001-2022-7072>
 - Professional email: <dfr@esmad.ipp.pt>
 - Personal email: <diogo.debastos.ribeiro@gmail.com>
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,6 @@
-sphinx
-myst-parser
+sphinx>=6.0
+myst-parser>=1.0.0,<4.0.0
+sphinx-rtd-theme
+sphinx-autodoc-typehints
+sphinx-copybutton
+sphinx-design

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,56 @@
+/* Custom styling for gen_surv documentation */
+
+/* Improve code block appearance */
+.highlight {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 4px;
+    padding: 10px;
+    margin: 10px 0;
+}
+
+/* Style admonitions */
+.admonition {
+    border-radius: 6px;
+    margin: 1em 0;
+    padding: 1em;
+}
+
+.admonition.tip {
+    border-left: 4px solid #28a745;
+    background-color: #d4edda;
+}
+
+.admonition.note {
+    border-left: 4px solid #007bff;
+    background-color: #cce5ff;
+}
+
+.admonition.warning {
+    border-left: 4px solid #ffc107;
+    background-color: #fff3cd;
+}
+
+/* Table styling */
+table.docutils {
+    border-collapse: collapse;
+    margin: 1em 0;
+    width: 100%;
+}
+
+table.docutils th,
+table.docutils td {
+    border: 1px solid #ddd;
+    padding: 8px;
+    text-align: left;
+}
+
+table.docutils th {
+    background-color: #f8f9fa;
+    font-weight: bold;
+}
+
+/* Math styling */
+.math {
+    font-size: 1.1em;
+}

--- a/docs/source/algorithms.md
+++ b/docs/source/algorithms.md
@@ -1,0 +1,44 @@
+# Algorithm Overview
+
+This page provides a short description of each model implemented in **gen_surv**.  For mathematical details see {doc}`theory`.
+
+## Cox Proportional Hazards Model (CPHM)
+The hazard at time $t$ is proportional to a baseline hazard multiplied by the exponential of covariate effects.
+It is widely used for modelling relative risks under the proportional hazards assumption.
+See {ref}`Cox1972` in the {doc}`bibliography` for the seminal paper.
+
+## Accelerated Failure Time Models (AFT)
+These parametric models directly relate covariates to survival time.
+gen_surv includes log-normal, log-logistic and Weibull variants allowing different baseline distributions.
+They are convenient when the effect of covariates accelerates or decelerates event times.
+
+## Continuous-Time Multi-State Markov Model (CMM)
+Transitions between states are governed by a generator matrix.
+This model is suited for illness-death and other multi-state processes where state occupancy changes continuously over time.
+The mathematical formulation follows the counting-process approach of Andersen et al. {ref}`Andersen1993`.
+
+## Time-Dependent Covariate Model (TDCM)
+Extends the Cox model to covariates that vary during follow-up.
+Covariates are simulated in a piecewise fashion with optional correlation across segments.
+
+## Time-Homogeneous Hidden Markov Model (THMM)
+Handles processes with unobserved states that emit observable values.
+The latent transitions follow a homogeneous Markov chain while emissions are Gaussian.
+For background on these models see Zucchini et al. {ref}`Zucchini2017`.
+
+## Competing Risks
+Allows multiple failure types with cause-specific hazards.
+gen_surv supports constant and Weibull hazards for each cause.
+The subdistribution approach of Fine and Gray {ref}`FineGray1999` is commonly used for analysis.
+
+## Mixture Cure Model
+Assumes a proportion of individuals will never experience the event.
+A logistic component determines who is cured, while uncured subjects follow an exponential failure distribution.
+Mixture cure models were introduced by Farewell {ref}`Farewell1982`.
+
+## Piecewise Exponential Model
+Approximates complex hazard shapes by dividing follow-up time into intervals with constant hazard within each interval.
+This yields a flexible baseline hazard while remaining computationally simple.
+
+For additional reading on these methods please see the {doc}`bibliography`.
+

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,0 +1,88 @@
+# API Reference
+
+Complete documentation for all gen_surv functions and classes.
+
+## Core Interface
+
+```{eval-rst}
+.. automodule:: gen_surv.interface
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+## Model Generators
+
+### Cox Proportional Hazards Model
+```{eval-rst}
+.. automodule:: gen_surv.cphm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Accelerated Failure Time Models
+```{eval-rst}
+.. automodule:: gen_surv.aft
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Continuous-Time Markov Models
+```{eval-rst}
+.. automodule:: gen_surv.cmm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Time-Dependent Covariate Models
+```{eval-rst}
+.. automodule:: gen_surv.tdcm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Time-Homogeneous Markov Models
+```{eval-rst}
+.. automodule:: gen_surv.thmm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+## Utility Functions
+
+### Censoring Functions
+```{eval-rst}
+.. automodule:: gen_surv.censoring
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Bivariate Distributions
+```{eval-rst}
+.. automodule:: gen_surv.bivariate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Validation Functions
+```{eval-rst}
+.. automodule:: gen_surv.validate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Command Line Interface
+```{eval-rst}
+.. automodule:: gen_surv.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/source/bibliography.md
+++ b/docs/source/bibliography.md
@@ -1,0 +1,22 @@
+# References
+
+Below is a selection of references covering the statistical models implemented in **gen_surv**.
+
+.. _Cox1972:
+Cox, D. R. (1972). Regression Models and Life-Tables. *Journal of the Royal Statistical Society: Series B*, 34(2), 187-220.
+
+.. _Farewell1982:
+Farewell, V.T. (1982). The Use of Mixture Models for the Analysis of Survival Data with Long-Term Survivors. *Biometrics*, 38(4), 1041-1046.
+
+.. _FineGray1999:
+Fine, J.P., & Gray, R.J. (1999). A Proportional Hazards Model for the Subdistribution of a Competing Risk. *Journal of the American Statistical Association*, 94(446), 496-509.
+
+.. _Andersen1993:
+Andersen, P.K., Borgan, Ø., Gill, R.D., & Keiding, N. (1993). *Statistical Models Based on Counting Processes*. Springer.
+
+.. _Zucchini2017:
+Zucchini, W., MacDonald, I.L., & Langrock, R. (2017). *Hidden Markov Models for Time Series*. Chapman and Hall/CRC.
+
+- Klein, J.P., & Moeschberger, M.L. (2003). *Survival Analysis: Techniques for Censored and Truncated Data*. Springer.
+- Kalbfleisch, J.D., & Prentice, R.L. (2002). *The Statistical Analysis of Failure Time Data*. Wiley.
+- Cook, R.J., & Lawless, J.F. (2007). *The Statistical Analysis of Recurrent Events*. Springer.

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+```{include} ../../CHANGELOG.md
+:relative: true
+```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,42 +1,92 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../gen_surv'))
+from pathlib import Path
 
+# Add the package to the Python path
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root / "gen_surv"))
+
+# Project information
 project = 'gen_surv'
 copyright = '2025, Diogo Ribeiro'
 author = 'Diogo Ribeiro'
 release = '1.0.8'
+version = '1.0.8'
 
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
+# General configuration
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "myst_parser",
     "sphinx.ext.viewcode",
-    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.githubpages",
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_design",
 ]
 
-autosectionlabel_prefix_document = True
+# MyST Parser configuration
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "html_admonition",
+    "html_image",
+    "linkify",
+    "replacements",
+    "smartquotes",
+    "substitution",
+    "tasklist",
+]
 
-# Point to index.md or index.rst as the root document
-master_doc = "index"
+# Autodoc configuration
+autodoc_default_options = {
+    'members': True,
+    'member-order': 'bysource',
+    'special-members': '__init__',
+    'undoc-members': True,
+    'exclude-members': '__weakref__'
+}
 
-templates_path = ['_templates']
-exclude_patterns = []
+# Autosummary
+autosummary_generate = True
 
-# -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
 
-html_theme = 'alabaster'
+# Intersphinx mapping
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
+}
+
+# HTML theme options
+html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    'canonical_url': 'https://gensurvpy.readthedocs.io/',
+    'analytics_id': '',
+    'logo_only': False,
+    'display_version': True,
+    'prev_next_buttons_location': 'bottom',
+    'style_external_links': False,
+    'style_nav_header_background': '#2980B9',
+    'collapse_navigation': True,
+    'sticky_navigation': True,
+    'navigation_depth': 4,
+    'includehidden': True,
+    'titles_only': False
+}
+
 html_static_path = ['_static']
+html_css_files = ['custom.css']
 
+# Output file base name for HTML help builder
+htmlhelp_basename = 'gensurvdoc'
 
+# Copy button configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -1,0 +1,5 @@
+# Contributing
+
+```{include} ../../CONTRIBUTING.md
+:relative: true
+```

--- a/docs/source/examples/index.md
+++ b/docs/source/examples/index.md
@@ -1,0 +1,8 @@
+# Examples
+
+Real-world examples and use cases for gen_surv.
+
+```{toctree}
+:maxdepth: 2
+
+```

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,0 +1,77 @@
+# Getting Started
+
+This guide will help you install gen_surv and generate your first survival dataset.
+
+## Installation
+
+### From PyPI (Recommended)
+
+```bash
+pip install gen-surv
+```
+
+### From Source
+
+```bash
+git clone https://github.com/DiogoRibeiro7/genSurvPy.git
+cd genSurvPy
+poetry install
+```
+
+## Basic Usage
+
+The main entry point is the `generate()` function:
+
+```python
+from gen_surv import generate
+
+# Generate Cox proportional hazards data
+ df = generate(
+     model="cphm",      # Model type
+     n=100,             # Sample size
+     beta=0.5,          # Covariate effect
+     covar=2.0,         # Covariate range
+     model_cens="uniform",  # Censoring type
+     cens_par=3.0       # Censoring parameter
+ )
+
+print(df.head())
+```
+
+## Understanding the Output
+
+All models return a pandas DataFrame with at least these columns:
+
+- `time`: Observed event or censoring time
+- `status`: Event indicator (1 = event, 0 = censored)
+- Additional columns depend on the specific model
+
+## Command Line Usage
+
+Generate datasets directly from the terminal:
+
+```bash
+# Generate CPHM data and save to CSV
+python -m gen_surv dataset cphm --n 1000 -o survival_data.csv
+
+# Print AFT data to stdout
+python -m gen_surv dataset aft_ln --n 500
+```
+
+## Next Steps
+
+- Explore the {doc}`tutorials/index` for detailed examples
+- Check the {doc}`api/index` for complete function documentation
+- Read about the {doc}`theory` behind each model
+
+## Building the Documentation
+
+To preview the documentation locally run:
+
+```bash
+cd docs
+make html
+```
+
+More details about our Read the Docs configuration can be found in {doc}`rtd`.
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,100 +1,135 @@
-# gen_surv
+# gen_surv: Survival Data Simulation in Python
 
-**gen_surv** is a Python package for simulating survival data under various models, inspired by the R package `genSurv`.
+[![Documentation Status](https://readthedocs.org/projects/gensurvpy/badge/?version=latest)](https://gensurvpy.readthedocs.io/en/latest/?badge=latest)
+[![PyPI version](https://badge.fury.io/py/gen-surv.svg)](https://badge.fury.io/py/gen-surv)
+[![Python versions](https://img.shields.io/pypi/pyversions/gen-surv.svg)](https://pypi.org/project/gen-surv/)
 
-It includes generators for:
+**gen_surv** is a comprehensive Python package for simulating survival data under various statistical models, inspired by the R package `genSurv`. It provides a unified interface for generating synthetic survival datasets that are essential for:
 
-- **Cox Proportional Hazards Models (CPHM)**
-- **Continuous-Time Markov Models (CMM)**
-- **Time-Dependent Covariate Models (TDCM)**
-- **Time-Homogeneous Hidden Markov Models (THMM)**
-- **Accelerated Failure Time (AFT) Log-Normal Models**
+- **Research**: Testing new survival analysis methods
+- **Education**: Teaching survival analysis concepts
+- **Benchmarking**: Comparing different survival models
+- **Validation**: Testing statistical software implementations
 
-Key functions include `generate()`, `gen_cphm()`, `gen_cmm()`, `gen_tdcm()`,
-`gen_thmm()`, `gen_aft_log_normal()`, `sample_bivariate_distribution()`,
-`runifcens()`, and `rexpocens()`.
+```{admonition} Quick Start
+:class: tip
 
----
+Install with pip:
+```bash
+pip install gen-surv
+```
 
-See the [Getting Started](usage) guide for installation instructions.
+Generate your first dataset:
+```python
+from gen_surv import generate
+df = generate(model="cphm", n=100, beta=0.5, covar=2.0)
+```
+```
 
-## 📚 Modules
+## Supported Models
+
+| Model | Description | Use Case |
+|-------|-------------|----------|
+| **CPHM** | Cox Proportional Hazards | Standard survival regression |
+| **AFT** | Accelerated Failure Time | Non-proportional hazards |
+| **CMM** | Continuous-Time Markov | Multi-state processes |
+| **TDCM** | Time-Dependent Covariates | Dynamic risk factors |
+| **THMM** | Time-Homogeneous Markov | Hidden state processes |
+| **Competing Risks** | Multiple event types | Cause-specific hazards |
+| **Mixture Cure** | Long-term survivors | Logistic cure fraction |
+| **Piecewise Exponential** | Piecewise constant hazard | Flexible baseline |
+
+## Algorithm Descriptions
+
+For a brief summary of each statistical model see {doc}`algorithms`. Mathematical
+details and notation are provided on the {doc}`theory` page.
+
+## Documentation Contents
 
 ```{toctree}
 :maxdepth: 2
-:caption: Contents
 
-usage
-modules
+getting_started
+tutorials/index
+api/index
 theory
+algorithms
+examples/index
+rtd
+contributing
+changelog
+bibliography
 ```
 
+## Quick Examples
 
-# 🚀 Usage Example
-
+### Cox Proportional Hazards Model
 ```python
-from gen_surv import generate
+import gen_surv as gs
 
-# CPHM
-generate(model="cphm", n=100, model_cens="uniform", cens_par=1.0, beta=0.5, covariate_range=2.0)
-
-# AFT Log-Normal
-generate(model="aft_ln", n=100, beta=[0.5, -0.3], sigma=1.0, model_cens="exponential", cens_par=3.0)
-
-# CMM
-generate(model="cmm", n=100, model_cens="exponential", cens_par=2.0,
-         qmat=[[0, 0.1], [0.05, 0]], p0=[1.0, 0.0])
-
-# TDCM
-generate(model="tdcm", n=100, dist="weibull", corr=0.5,
-         dist_par=[1, 2, 1, 2], model_cens="uniform", cens_par=1.0,
-         beta=[0.1, 0.2, 0.3], lam=1.0)
-
-# THMM
-generate(model="thmm", n=100, qmat=[[0, 0.2, 0], [0.1, 0, 0.1], [0, 0.3, 0]],
-         emission_pars={"mu": [0.0, 1.0, 2.0], "sigma": [0.5, 0.5, 0.5]},
-         p0=[1.0, 0.0, 0.0], model_cens="exponential", cens_par=3.0)
+# Basic CPHM with uniform censoring
+df = gs.generate(
+    model="cphm", 
+    n=500, 
+    beta=0.5, 
+    covar=2.0,
+    model_cens="uniform", 
+    cens_par=3.0
+)
 ```
 
-## ⌨️ Command-Line Usage
-
-Generate datasets directly from the terminal:
-
-```bash
-python -m gen_surv dataset aft_ln --n 100 > data.csv
+### Accelerated Failure Time Model
+```python
+# AFT with log-normal distribution
+df = gs.generate(
+    model="aft_ln",
+    n=200,
+    beta=[0.5, -0.3, 0.2],
+    sigma=1.0,
+    model_cens="exponential",
+    cens_par=2.0
+)
 ```
 
-## Repository Layout
-
-```text
-genSurvPy/
-├── gen_surv/
-│   └── ...
-├── tests/
-├── examples/
-├── docs/
-├── scripts/
-├── tasks.py
-└── TODO.md
+### Multi-State Markov Model
+```python
+# Three-state illness-death model
+df = gs.generate(
+    model="cmm",
+    n=300,
+    qmat=[[0, 0.1], [0.05, 0]],
+    p0=[1.0, 0.0],
+    model_cens="uniform",
+    cens_par=5.0
+)
 ```
 
-## 🔗 Project Links
+## Key Features
 
-- [Source Code](https://github.com/DiogoRibeiro7/genSurvPy)
-- [License](https://github.com/DiogoRibeiro7/genSurvPy/blob/main/LICENCE)
-- [Code of Conduct](https://github.com/DiogoRibeiro7/genSurvPy/blob/main/CODE_OF_CONDUCT.md)
-
+- **Unified Interface**: Single `generate()` function for all models
+- **Flexible Censoring**: Support for uniform and exponential censoring
+- **Rich Parameterization**: Extensive customization options
+- **Command-Line Interface**: Generate datasets from terminal
+- **Comprehensive Validation**: Input parameter checking
+- **Educational Focus**: Clear mathematical documentation
 
 ## Citation
 
-If you use **gen_surv** in your work, please cite it using the metadata in
-[CITATION.cff](../../CITATION.cff).
+If you use gen_surv in your research, please cite:
 
-## Author
+```bibtex
+@software{ribeiro2025gensurvpy,
+  title = {gen_surv: Survival Data Simulation in Python},
+  author = {Diogo Ribeiro},
+  year = {2025},
+  url = {https://github.com/DiogoRibeiro7/genSurvPy},
+  version = {1.0.8}
+}
+```
 
-**Diogo Ribeiro** — [ESMAD - Instituto Politécnico do Porto](https://esmad.ipp.pt)
+## License
 
-- ORCID: <https://orcid.org/0009-0001-2022-7072>
-- Professional email: <dfr@esmad.ipp.pt>
-- Personal email: <diogo.debastos.ribeiro@gmail.com>
+MIT License - see [LICENSE](https://github.com/DiogoRibeiro7/genSurvPy/blob/main/LICENCE) for details.
 
+For foundational papers related to these models see the {doc}`bibliography`.
+Information on building the docs is provided in the {doc}`rtd` page.

--- a/docs/source/rtd.md
+++ b/docs/source/rtd.md
@@ -1,0 +1,16 @@
+# Read the Docs
+
+This project uses [Read the Docs](https://readthedocs.org/) to host its documentation. The site is automatically rebuilt whenever changes are pushed to the repository.
+
+Our build configuration is defined in `.readthedocs.yml`. It installs the package with the `docs` dependency group and builds the Sphinx docs using Python 3.11.
+
+## Building Locally
+
+To preview the documentation on your machine, run:
+
+```bash
+cd docs
+make html
+```
+
+Open `build/html/index.html` in your browser to view the result.

--- a/docs/source/theory.md
+++ b/docs/source/theory.md
@@ -6,7 +6,9 @@ This page presents the mathematical formulation behind the survival models imple
 
 ## 1. Cox Proportional Hazards Model (CPHM)
 
-The hazard function conditioned on covariates is:
+This semi-parametric approach models the hazard as a baseline component
+multiplied by an exponential term involving the covariates. The hazard
+function conditioned on covariates is:
 
 $$
 h(t \mid X) = h_0(t) \exp(X \\beta)
@@ -39,7 +41,8 @@ $$
 
 ## 2. Time-Dependent Covariate Model (TDCM)
 
-A generalization of CPHM where covariates change over time:
+This extension of the Cox model allows covariate values to vary during
+follow-up, accommodating exposures or treatments that change over time:
 
 $$
 h(t \mid Z(t)) = h_0(t) \\exp(Z(t) \\beta)
@@ -51,7 +54,8 @@ In this package, piecewise covariate values are simulated with dependence across
 
 ## 3. Continuous-Time Multi-State Markov Model (CMM)
 
-Markov model with generator matrix \( Q \). The transition probability matrix is given by:
+This framework captures transitions between a finite set of states where
+waiting times are exponentially distributed. With generator matrix \( Q \), the transition probability matrix is given by:
 
 $$
 P(t) = \\exp(Qt)
@@ -66,7 +70,9 @@ Where:
 
 ## 4. Time-Homogeneous Hidden Markov Model (THMM)
 
-This model simulates observed states with unobserved latent state transitions.
+This model handles situations where the process evolves through unobserved
+states that generate the observed responses. It simulates observed states with
+latent transitions.
 
 Let:
 
@@ -84,7 +90,9 @@ $$
 
 ## 5. Accelerated Failure Time (AFT) Models
 
-AFT models assume that the effect of covariates accelerates or decelerates time to event directly, rather than the hazard.
+These fully parametric models relate covariates to the logarithm of the
+survival time. They assume the effect of a covariate speeds up or slows down the
+event time directly, rather than acting on the hazard.
 
 ### Log-Normal AFT
 
@@ -121,19 +129,20 @@ All models support censoring:
 
 ## 6. Competing Risks Models
 
-These models simulate multiple mutually exclusive event types. Each cause has its
-own hazard function, and the observed status indicates which event occurred
-(1, 2, ...). The package includes constant-hazard and Weibull-hazard versions.
+These models handle scenarios where several distinct failure types can occur.
+Each cause has its own hazard function, and the observed status indicates which
+event occurred (1, 2, ...). The package includes constant-hazard and
+Weibull-hazard versions.
 
 ## 7. Mixture Cure Models
 
-Mixture cure models assume a proportion of subjects are immune to the event. The
-generator mixes a logistic cure component with an exponential hazard for the
-uncured, returning a ``cured`` indicator column alongside the usual time and
-status.
+These models posit that a subset of the population is cured and will never
+experience the event of interest. The generator mixes a logistic cure component
+with an exponential hazard for the uncured, returning a ``cured`` indicator
+column alongside the usual time and status.
 
 ## 8. Piecewise Exponential Model
 
-This model divides the time axis into intervals defined by user-supplied
-breakpoints. Each interval has its own hazard rate, allowing flexible hazard
-shapes over time.
+Here the baseline hazard is assumed constant within each of several
+user-specified intervals. This allows flexible hazard shapes over time while
+remaining easy to simulate.

--- a/docs/source/tutorials/basic_usage.md
+++ b/docs/source/tutorials/basic_usage.md
@@ -1,0 +1,110 @@
+# Basic Usage Tutorial
+
+This tutorial covers the fundamentals of generating survival data with gen_surv.
+
+## Your First Dataset
+
+Let's start with the simplest case - generating data from a Cox proportional hazards model:
+
+```python
+from gen_surv import generate
+import pandas as pd
+
+# Generate basic CPHM data
+ df = generate(
+     model="cphm",
+     n=200,
+     beta=0.7,
+     covar=1.5,
+     model_cens="exponential",
+     cens_par=2.0,
+     seed=42  # For reproducibility
+ )
+
+print(f"Dataset shape: {df.shape}")
+print(f"Event rate: {df['status'].mean():.2%}")
+print("\nFirst 5 rows:")
+print(df.head())
+```
+
+## Understanding Parameters
+
+### Common Parameters
+
+All models share these parameters:
+
+- `n`: Sample size (number of individuals)
+- `model_cens`: Censoring type ("uniform" or "exponential")
+- `cens_par`: Censoring distribution parameter
+- `seed`: Random seed for reproducibility
+
+### Model-Specific Parameters
+
+Each model has unique parameters. For CPHM:
+
+- `beta`: Covariate effect (hazard ratio = exp(beta))
+- `covar`: Range for uniform covariate generation [0, covar]
+
+## Censoring Mechanisms
+
+gen_surv supports two censoring types:
+
+### Uniform Censoring
+```python
+# Censoring times uniformly distributed on [0, cens_par]
+df_uniform = generate(
+    model="cphm",
+    n=100,
+    beta=0.5,
+    covar=2.0,
+    model_cens="uniform",
+    cens_par=3.0
+)
+```
+
+### Exponential Censoring
+```python
+# Censoring times exponentially distributed with mean cens_par
+df_exponential = generate(
+    model="cphm",
+    n=100,
+    beta=0.5,
+    covar=2.0,
+    model_cens="exponential",
+    cens_par=2.0
+)
+```
+
+## Exploring Your Data
+
+Basic data exploration:
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+# Event rate by covariate level
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
+
+# Histogram of survival times
+ax1.hist(df['time'], bins=20, alpha=0.7, edgecolor='black')
+ax1.set_xlabel('Time')
+ax1.set_ylabel('Frequency')
+ax1.set_title('Distribution of Observed Times')
+
+# Event rate vs covariate
+df['covar_bin'] = pd.cut(df['covariate'], bins=5)
+event_rate = df.groupby('covar_bin')['status'].mean()
+event_rate.plot(kind='bar', ax=ax2, rot=45)
+ax2.set_ylabel('Event Rate')
+ax2.set_title('Event Rate by Covariate Level')
+
+plt.tight_layout()
+plt.show()
+```
+
+## Next Steps
+
+- Try different models: {doc}`model_comparison`
+- Learn advanced features: {doc}`advanced_features`  
+- See integration examples: {doc}`integration_examples`

--- a/docs/source/tutorials/index.md
+++ b/docs/source/tutorials/index.md
@@ -1,0 +1,9 @@
+# Tutorials
+
+Step-by-step guides for using gen_surv effectively.
+
+```{toctree}
+:maxdepth: 2
+
+basic_usage
+```

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -31,3 +31,15 @@ python -m gen_surv dataset aft_ln --n 100 > data.csv
 
 For a full description of available models and parameters, see the API reference.
 
+
+## Building the Documentation
+
+Documentation is written using [Sphinx](https://www.sphinx-doc.org). To build the HTML pages locally run:
+
+```bash
+cd docs
+make html
+```
+
+The generated files will be available under `docs/build/html`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,12 @@ isort = "^5.13.2"
 flake8 = "^6.1.0"
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "^7.2.6"
-myst-parser = "<4.0.0"
+sphinx = ">=6.0"
 sphinx-rtd-theme = "^1.3.0"
+myst-parser = ">=1.0.0,<4.0.0"
+sphinx-autodoc-typehints = "^1.24.0"
+sphinx-copybutton = "^0.5.2"
+sphinx-design = "^0.5.0"
 
 [tool.poetry.scripts]
 gen_surv = "gen_surv.cli:app"

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from gen_surv.mixture import cure_fraction_estimate, gen_mixture_cure
 
@@ -12,5 +13,71 @@ def test_gen_mixture_cure_runs():
 
 def test_cure_fraction_estimate_range():
     df = gen_mixture_cure(n=50, cure_fraction=0.3, seed=0)
+    est = cure_fraction_estimate(df)
+    assert 0 <= est <= 1
+
+
+def test_cure_fraction_estimate_empty_returns_zero():
+    df = pd.DataFrame(columns=["time", "status"])
+    est = cure_fraction_estimate(df)
+    assert est == 0.0
+
+
+def test_gen_mixture_cure_invalid_inputs():
+    with pytest.raises(ValueError):
+        gen_mixture_cure(n=5, cure_fraction=1.5)
+    with pytest.raises(ValueError):
+        gen_mixture_cure(n=5, cure_fraction=0.2, baseline_hazard=0)
+    with pytest.raises(ValueError):
+        gen_mixture_cure(n=5, cure_fraction=0.2, covariate_dist="bad")
+    with pytest.raises(ValueError):
+        gen_mixture_cure(n=5, cure_fraction=0.2, model_cens="bad")
+    with pytest.raises(ValueError):
+        gen_mixture_cure(
+            n=5,
+            cure_fraction=0.2,
+            betas_survival=[0.1, 0.2],
+            betas_cure=[0.1],
+        )
+
+
+def test_gen_mixture_cure_max_time_cap():
+    df = gen_mixture_cure(
+        n=50,
+        cure_fraction=0.3,
+        max_time=5.0,
+        model_cens="exponential",
+        cens_par=1.0,
+        seed=123,
+    )
+    assert (df["time"] <= 5.0).all()
+
+
+def test_cure_fraction_estimate_close_to_true():
+    df = gen_mixture_cure(n=200, cure_fraction=0.4, seed=1)
+    est = cure_fraction_estimate(df)
+    assert pytest.approx(0.4, abs=0.15) == est
+
+
+def test_gen_mixture_cure_covariate_distributions():
+    for dist in ["uniform", "binary"]:
+        df = gen_mixture_cure(n=20, cure_fraction=0.3, covariate_dist=dist, seed=2)
+        assert {"time", "status", "cured", "X0", "X1"}.issubset(df.columns)
+
+
+def test_gen_mixture_cure_no_max_time_allows_long_times():
+    df = gen_mixture_cure(
+        n=100,
+        cure_fraction=0.5,
+        max_time=None,
+        model_cens="uniform",
+        cens_par=20.0,
+        seed=3,
+    )
+    assert df["time"].max() > 10
+
+
+def test_cure_fraction_estimate_small_sample():
+    df = gen_mixture_cure(n=3, cure_fraction=0.2, seed=4)
     est = cure_fraction_estimate(df)
     assert 0 <= est <= 1


### PR DESCRIPTION
## Summary
- refine algorithm overview and link to bibliography
- maintain detailed Read the Docs guide
- expand reference list and cross-links
- ensure mixture cure tests keep high coverage
- rewrite the README

## Testing
- `pytest --cov=gen_surv.mixture tests/test_mixture.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889ea2df7ac8325b28432621a545d00