### PR TITLE
fix: make optional deps lazy, normalize ids, stabilize tests

### DIFF
--- a/gen_surv/cmm.py
+++ b/gen_surv/cmm.py
@@ -125,7 +125,7 @@ def gen_cmm(
 
     return pd.DataFrame(
         {
-            "id": np.arange(1, n + 1),
+            "id": np.arange(n),
             "start": np.zeros(n),
             "stop": stop,
             "status": status,

--- a/gen_surv/export.py
+++ b/gen_surv/export.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import os
 
 import pandas as pd
-import pyreadr
 
 from .validation import ensure_in_choices
 
@@ -44,4 +43,10 @@ def export_dataset(df: pd.DataFrame, path: str, fmt: str | None = None) -> None:
     elif fmt in {"feather", "ft"}:
         df.reset_index(drop=True).to_feather(path)
     elif fmt == "rds":
+        try:
+            import pyreadr  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+            raise ModuleNotFoundError(
+                "pyreadr is required for RDS export; install the 'pyreadr' package."
+            ) from exc
         pyreadr.write_rds(path, df.reset_index(drop=True))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package marker to ensure local imports resolve correctly."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Callable
 
 import numpy as np
 import pandas as pd
 import pytest
+
+os.environ.setdefault("MPLBACKEND", "Agg")
 
 BASELINE_DIR = Path(__file__).parent / "baselines"
 BASELINE_DIR.mkdir(exist_ok=True)

--- a/tests/test_aft.py
+++ b/tests/test_aft.py
@@ -4,7 +4,7 @@ Tests for Accelerated Failure Time (AFT) models.
 
 import pandas as pd
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from gen_surv.aft import gen_aft_log_logistic, gen_aft_log_normal, gen_aft_weibull
@@ -59,6 +59,7 @@ def test_gen_aft_log_logistic_invalid_scale():
         )
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow], max_examples=50)
 @given(
     n=st.integers(min_value=1, max_value=20),
     shape=st.floats(

--- a/tests/test_cmm.py
+++ b/tests/test_cmm.py
@@ -29,7 +29,7 @@ def test_gen_cmm_uniform_reproducible():
     )
     expected = pd.DataFrame(
         {
-            "id": [1, 2, 3, 4, 5],
+            "id": [0, 1, 2, 3, 4],
             "start": [0.0] * 5,
             "stop": [
                 0.18915094163423693,
@@ -64,7 +64,7 @@ def test_gen_cmm_exponential_reproducible():
     )
     expected = pd.DataFrame(
         {
-            "id": [1, 2, 3, 4, 5],
+            "id": [0, 1, 2, 3, 4],
             "start": [0.0] * 5,
             "stop": [
                 0.18915094163423693,

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pyreadr
 import pytest
 
 from gen_surv.export import export_dataset
@@ -41,6 +40,7 @@ def test_export_dataset_json(monkeypatch, tmp_path):
 
 
 def test_export_dataset_rds(monkeypatch, tmp_path):
+    pyreadr = pytest.importorskip("pyreadr")
     df = pd.DataFrame({"time": [1.0, 2.0], "status": [1, 0]})
     out = tmp_path / "data.rds"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lazy-load the RDS export dependency and switch CMM IDs to 0-based indexing. This avoids import errors when pyreadr isn’t installed and aligns IDs with zero-based conventions while making tests deterministic.

- **Bug Fixes**
  - RDS export now imports pyreadr only when used and raises a clear error if missing.
  - Tests stabilized by forcing a non-GUI matplotlib backend, limiting Hypothesis examples, and skipping RDS tests when pyreadr is absent.

- **Migration**
  - gen_cmm now outputs id starting at 0 (was 1). Update any expectations or baselines relying on 1-based ids.

<sup>Written for commit abde8709c63d27b74f6adce1a4ca32ad61c58432. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

