### PR TITLE
ci: publish the documentation to GitHub Pages on release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,97 @@
+# .github/workflows/gh-pages.yml
+
+name: GitHub Pages
+
+# The site documents the released version, so it is rebuilt from the tag that
+# was published to PyPI rather than from every push to main. Checking out the
+# tag also means autodoc and the version banner read the released package.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one deployment at a time and let a running one finish, so the site is
+# never left half-published.
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      # A workflow_dispatch that does not select a ref targets `develop`, this
+      # repository's default branch. The published site must track the release,
+      # so refuse anything that is not a release tag or `main`.
+      - name: Verify the run is on a release
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          case "$REF" in
+            refs/tags/v*|refs/heads/main)
+              echo "Building the documentation from $REF."
+              ;;
+            *)
+              echo "::error::Refusing to publish documentation from '$REF'. The site tracks the version released to PyPI, so it can only be built from a 'v*' tag or from 'main'."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-3.11-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install --with docs --no-interaction
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
+
+      - name: Build documentation
+        env:
+          DOCS_BASEURL: ${{ steps.pages.outputs.base_url }}
+        run: poetry run sphinx-build -W --keep-going -b html -c docs/gh_conf docs/source docs/build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Coverage][cov-badge]][cov-link]
 [![Docs][docs-badge]][docs-link]
+[![GitHub Pages][pages-badge]][pages-link]
 [![PyPI][pypi-badge]][pypi-link]
 [![Tests][ci-badge]][ci-link]
 [![Python][py-badge]][pypi-link]
@@ -10,6 +11,8 @@
 [cov-link]: https://app.codecov.io/gh/DiogoRibeiro7/genSurvPy
 [docs-badge]: https://readthedocs.org/projects/gensurvpy/badge/?version=latest
 [docs-link]: https://gensurvpy.readthedocs.io/en/latest/
+[pages-badge]: https://github.com/DiogoRibeiro7/genSurvPy/actions/workflows/gh-pages.yml/badge.svg
+[pages-link]: https://diogoribeiro7.github.io/genSurvPy/
 [pypi-badge]: https://img.shields.io/pypi/v/gen_surv
 [pypi-link]: https://pypi.org/project/gen-surv/
 [ci-badge]: https://github.com/DiogoRibeiro7/genSurvPy/actions/workflows/ci.yml/badge.svg
@@ -129,13 +132,20 @@ More details on each algorithm are available in the [Algorithms](https://gensurv
 
 ## Documentation
 
-Full documentation is hosted on [Read the Docs](https://gensurvpy.readthedocs.io/en/latest/). It includes installation instructions, tutorials, API references and a bibliography.
+Full documentation is hosted on [Read the Docs](https://gensurvpy.readthedocs.io/en/latest/) and mirrored on [GitHub Pages](https://diogoribeiro7.github.io/genSurvPy/). Both are built from `docs/source` and include installation instructions, tutorials, API references and a bibliography. The GitHub Pages site is rebuilt from the release tag by the [`GitHub Pages` workflow](.github/workflows/gh-pages.yml), so it documents the version currently on PyPI rather than unreleased work on `develop`.
 
 To build the docs locally:
 
 ```bash
 cd docs
 make html
+```
+
+To reproduce the GitHub Pages build (same configuration as the workflow):
+
+```bash
+poetry install --with docs
+poetry run sphinx-build -b html -c docs/gh_conf docs/source docs/build
 ```
 
 Open `build/html/index.html` in your browser to view the result.

--- a/docs/gh_conf/conf.py
+++ b/docs/gh_conf/conf.py
@@ -1,27 +1,35 @@
-# conf_pages.py — for GitHub Pages deployment
+"""Sphinx configuration for HTML served from a GitHub Pages site.
+
+Reuses ``docs/source/conf.py`` and overrides only what differs when the docs are
+published on GitHub Pages instead of Read the Docs. Build with::
+
+    sphinx-build -b html -c docs/gh_conf docs/source docs/build
+"""
 
 import os
 import sys
+from pathlib import Path
 
-# Import the main documentation configuration
-# Assumes this file is located in docs/gh_conf/
-# and main conf.py is in docs/source/
-sys.path.insert(0, os.path.abspath("../source"))
+_SOURCE_DIR = Path(__file__).resolve().parent.parent / "source"
+
+# Import the main documentation configuration.
+sys.path.insert(0, str(_SOURCE_DIR))
 from conf import *  # noqa
 
-# Override base URL for correct links and assets on GitHub Pages
-html_baseurl = "https://diogoribeiro7.github.io/packages/gensurvpy/"
+# Paths in the imported configuration are relative to its own directory, but
+# Sphinx resolves them against this file instead, so make them absolute.
+html_static_path = [str(_SOURCE_DIR / "_static")]
 
-# Ensure that GitHub Pages serves _static and other underscored folders
-html_extra_path = [".nojekyll"]
+# ``actions/configure-pages`` exports the site URL as ``DOCS_BASEURL``. The
+# fallback keeps the older blog deployment (``sphinx-docs.yaml``) working.
+_base_url = (
+    os.environ.get("DOCS_BASEURL")
+    or "https://diogoribeiro7.github.io/packages/gensurvpy"
+)
+html_baseurl = _base_url.rstrip("/") + "/"
 
-# Optional: use a different theme for GitHub Pages if desired
-# html_theme = "furo"
+# Canonical links should point at the site being built, not at Read the Docs.
+html_theme_options["canonical_url"] = html_baseurl  # noqa: F405
 
-# Optional: override theme options for GitHub Pages
-# html_theme_options = {
-#     "navigation_with_keys": True,
-# }
-
-# Optional: override output directory (if not handled in sphinx-build command)
-# html_output = "build"
+# ``sphinx.ext.githubpages`` writes the .nojekyll file that makes GitHub Pages
+# serve the underscored ``_static`` and ``_sources`` directories.


### PR DESCRIPTION
Publishes the Sphinx docs to this repository's own GitHub Pages site at https://diogoribeiro7.github.io/genSurvPy/.

The workflow runs on `release: published` (plus `workflow_dispatch`), so the site is built from the tag that `publish.yml` uploaded to PyPI — the published docs always describe the released version, not unreleased work on `develop`. A guard step refuses any ref that is not a `v*` tag or `main`, mirroring the guard in `publish.yml`, because a `workflow_dispatch` without a ref selector targets the default branch (`develop`).

Also fixes two bugs in `docs/gh_conf/conf.py`, which no build had exercised correctly:

- `html_static_path` was inherited from `docs/source/conf.py` but Sphinx resolves it against the config directory, so `_static` did not exist and `custom.css` was never copied into a Pages build.
- `html_extra_path = [".nojekyll"]` pointed at a file that does not exist (a warning, and fatal under `-W`). `sphinx.ext.githubpages` already writes `.nojekyll`.
- `html_baseurl` now comes from `actions/configure-pages` via `DOCS_BASEURL` instead of being hardcoded, with the old blog path kept as the fallback so `sphinx-docs.yaml` is unaffected. `canonical_url` follows it rather than pointing at Read the Docs.

Repository settings already applied: Pages is enabled with the GitHub Actions source, and the `github-pages` environment allows deployments from `main` and `v*` tags only.

Verified locally: `sphinx-build -W --keep-going -b html -c docs/gh_conf docs/source docs/build` succeeds with zero warnings and emits `.nojekyll`, `_static/custom.css`, and canonical links under `https://diogoribeiro7.github.io/genSurvPy/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes Sphinx docs to GitHub Pages on release so the site matches the version on PyPI, not unreleased work. Previously, docs were only on Read the Docs; now they are mirrored on Pages and built from the release tag.

- Review
  - Adds `.github/workflows/gh-pages.yml` that runs on `release: published` and `workflow_dispatch`, rejects refs other than `v*` tags or `main`, uses `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`, and serializes deploys with a concurrency group.
  - Fixes Pages Sphinx config (`docs/gh_conf/conf.py`): makes `html_static_path` absolute so `_static/custom.css` is included; removes `html_extra_path` since `sphinx.ext.githubpages` writes `.nojekyll`; derives `html_baseurl` from `DOCS_BASEURL` and sets a matching `canonical_url`.
  - Updates README: adds a Pages badge, documents the Pages mirror, and shows how to reproduce the workflow build using `docs/gh_conf`.

- Rollout
  - No code migrations; keep editing `docs/source`.
  - Tag releases as `v*`; Pages deploys from `v*` tags and `main` only.

<sup>Written for commit 95f1f9f6de0b4159b7de1eeeaa8d8467318d9ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

