### PR TITLE
chore(release): prepare 2.0.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
   "title": "gen_surv: Survival Data Simulation in Python",
   "upload_type": "software",
-  "version": "2.0.0",
-  "publication_date": "2026-08-10",
+  "version": "2.0.1",
+  "publication_date": "2026-08-23",
   "description": "<p><strong>gen_surv</strong> is a Python library for simulating survival data and producing visualizations under a wide range of statistical models. Inspired by the R package <a href=\"https://cran.r-project.org/package=genSurv\">genSurv</a>, it provides a unified interface for generating synthetic survival datasets for research, teaching, benchmarking, and statistical software validation.</p>",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CHANGELOG
 
+## v2.0.1 (2026-08-23)
+
+No library changes: `gen_surv` behaves exactly as it does in v2.0.0. This release
+publishes the documentation site and relaxes dependency ranges that were pinned
+to a single major version.
+
+### Continuous Integration
+- The Sphinx documentation is now published to GitHub Pages at
+  <https://diogoribeiro7.github.io/genSurvPy/>. The site is built when a release
+  is published, from the tag that was uploaded to PyPI, so it always documents
+  the released version rather than unreleased work on `develop`.
+
+### Documentation
+- Fixed the GitHub Pages Sphinx configuration. It inherited `html_static_path`
+  from `docs/source/conf.py`, but Sphinx resolves that against the configuration
+  directory, so `_static` did not exist and `custom.css` was never copied into
+  the built site. It also pointed `html_extra_path` at a `.nojekyll` file that
+  does not exist, which `sphinx.ext.githubpages` already writes. The site base
+  URL now comes from the workflow rather than being hardcoded.
+
+### Misc
+- `pyarrow` accepts `>=21,<26` instead of `^21.0.0`, so it no longer holds
+  installations back to the 21.x series.
+- Widened the development and documentation dependency ranges for `pytest`,
+  `invoke`, `black`, `isort`, `flake8`, `scikit-survival`, `myst-parser` and
+  `sphinx-design`.
+
 ## v2.0.0 (2026-08-10)
 
 Completes the illness-death models. `gen_cmm` and `gen_thmm` previously reported

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ message: "If you use this software, please cite it using the metadata below."
 preferred-citation:
   type: software
   title: "gen_surv"
-  version: "2.0.0"
+  version: "2.0.1"
   url: "https://github.com/DiogoRibeiro7/genSurvPy"
   authors:
     - family-names: Ribeiro
@@ -15,5 +15,5 @@ preferred-citation:
       affiliation: "ESMAD - Instituto Politécnico do Porto"
       email: "dfr@esmad.ipp.pt"
   license: "MIT"
-  date-released: "2026-08-10"
+  date-released: "2026-08-23"
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -130,7 +130,7 @@ If you use gen_surv in your research, please cite:
   author = {Diogo Ribeiro},
   year = {2025},
   url = {https://github.com/DiogoRibeiro7/genSurvPy},
-  version = {2.0.0}
+  version = {2.0.1}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen_surv"
-version = "2.0.0"
+version = "2.0.1"
 description = "A Python package for simulating survival data, inspired by the R package genSurv"
 authors = ["Diogo Ribeiro <diogo.debastos.ribeiro@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Prepares the 2.0.1 release.

`gen_surv` itself is unchanged since 2.0.0 — `git diff v2.0.0..develop` touches no module under `gen_surv/`. The release exists to publish the documentation site and to relax dependency ranges that were pinned to a single major version, the only runtime-visible one being `pyarrow` (`^21.0.0` → `>=21,<26`).

Bumps the version in the four files `publish.yml` cross-checks — `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, and the BibTeX snippet in `docs/source/index.md` — and dates the release 2026-08-23 in the CFF and Zenodo metadata.

Verified locally: the version-consistency script from `publish.yml` reports no problems, and the suite passes (253 passed, 4 skipped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the 2.0.1 release to publish the documentation site and relax dependency ranges without changing library behavior. `pyarrow` moves from `^21.0.0` to `>=21,<26` to allow newer versions.

- No code changes under `gen_surv/`; review focuses on metadata and `CHANGELOG.md`.
- Version set to 2.0.1 dated 2026-08-23 in `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, and the docs’ BibTeX snippet.
- Dependency ranges widened; runtime-visible change is `pyarrow >=21,<26` (dev/doc deps also broadened).
- Sphinx docs now publish to GitHub Pages from the release tag. No user migration required.

<sup>Written for commit 5aeda28e326fd8a9196ca714f07111e863c5e27a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

