### PR TITLE
fix: draw middle-interval events at their own piecewise hazard

### DIFF
--- a/gen_surv/piecewise.py
+++ b/gen_surv/piecewise.py
@@ -132,6 +132,14 @@ def gen_piecewise_exponential(
         remaining_time -= hazard * interval_width
 
         # Go through middle intervals [breakpoints[j-1], breakpoints[j])
+        #
+        # The ``else`` belongs to the ``for``: it runs only when the loop was
+        # not broken out of, meaning the subject outlived every bounded
+        # interval. Releases up to 2.0.1 used a trailing ``if remaining_time >
+        # 0`` here instead, which also ran after the ``break`` and overwrote
+        # the time just computed with one derived from the *last* hazard rate.
+        # Any event falling in a middle interval was therefore drawn at the
+        # wrong rate.
         for j in range(1, len(breakpoints)):
             interval_width = breakpoints[j] - breakpoints[j - 1]
             hazard = adjusted_hazard_rates[j]
@@ -145,10 +153,9 @@ def gen_piecewise_exponential(
             # Event occurs after this interval
             total_time += interval_width
             remaining_time -= hazard * interval_width
-
-        # If we've gone through all intervals and still no event,
-        # use the last hazard rate for the remainder
-        if remaining_time > 0:
+        else:
+            # Survived every bounded interval: the remainder is consumed at the
+            # open-ended last rate.
             hazard = adjusted_hazard_rates[-1]
             survival_times[i] = total_time + remaining_time / hazard
 

--- a/tests/test_piecewise_hazards.py
+++ b/tests/test_piecewise_hazards.py
@@ -1,0 +1,143 @@
+"""Distributional tests for the piecewise exponential generator.
+
+These assert that each interval carries the hazard it was given, rather than
+only that the returned frame has the right shape. The defect they guard against
+shipped through 2.0.1: an event falling in a *middle* interval had its time
+recomputed with the last hazard rate, because the trailing "no event yet" branch
+ran even after the loop had broken out with a time already assigned.
+
+All draws use fixed seeds, so a failure is a real regression rather than Monte
+Carlo noise.
+"""
+
+import numpy as np
+import pandas as pd
+
+from gen_surv.piecewise import gen_piecewise_exponential
+
+# Large enough to pin each interval's hazard, small enough to keep CI quick.
+_N = 60_000
+_SEED = 20260823
+
+# Effectively no censoring: every event time is observed, so occurrence over
+# exposure estimates the hazard directly.
+_NO_CENSORING = 1e9
+
+
+def _empirical_hazard(frame: pd.DataFrame, low: float, high: float) -> float:
+    """Estimate the hazard on ``[low, high)`` as events over time at risk."""
+    at_risk = frame.loc[frame["time"] > low, "time"]
+    exposure = float(np.minimum(at_risk, high).sub(low).clip(lower=0).sum())
+    events = int(
+        ((frame["time"] > low) & (frame["time"] <= high) & (frame["status"] == 1)).sum()
+    )
+    return events / exposure
+
+
+def _generate(breakpoints: list[float], hazard_rates: list[float]) -> pd.DataFrame:
+    """Draw a sample whose hazard is the baseline alone, with no censoring."""
+    return gen_piecewise_exponential(
+        n=_N,
+        breakpoints=breakpoints,
+        hazard_rates=hazard_rates,
+        betas=[0.0, 0.0],  # covariates present but inert, so hazard == baseline
+        model_cens="uniform",
+        cens_par=_NO_CENSORING,
+        seed=_SEED,
+    )
+
+
+def test_single_breakpoint_hazards_match() -> None:
+    """The two-interval case, which was already correct, stays correct."""
+    breakpoints, rates = [1.0], [0.5, 2.0]
+    frame = _generate(breakpoints, rates)
+
+    edges = [0.0, *breakpoints, float(frame["time"].max())]
+    for low, high, declared in zip(edges[:-1], edges[1:], rates):
+        estimate = _empirical_hazard(frame, low, high)
+        np.testing.assert_allclose(
+            estimate,
+            declared,
+            rtol=0.05,
+            err_msg=f"hazard on [{low}, {high})",
+        )
+
+
+def test_middle_interval_uses_its_own_hazard() -> None:
+    """A middle interval must use its own rate, not the last one.
+
+    This is the regression: with ``breakpoints=[1.0, 3.0]`` the interval
+    ``[1, 3)`` came out at 0.2 -- the final rate -- instead of its declared 2.0,
+    a tenfold error in the data with nothing in the frame to reveal it.
+    """
+    breakpoints, rates = [1.0, 3.0], [0.5, 2.0, 0.2]
+    frame = _generate(breakpoints, rates)
+
+    middle = _empirical_hazard(frame, 1.0, 3.0)
+
+    np.testing.assert_allclose(middle, rates[1], rtol=0.05)
+    assert abs(middle - rates[-1]) > 1.0, (
+        f"middle interval hazard {middle:.3f} matches the last declared rate "
+        f"{rates[-1]}, which is the pre-2.0.2 overwrite bug"
+    )
+
+
+def test_every_interval_matches_its_declared_hazard() -> None:
+    """All three intervals of a two-breakpoint specification."""
+    breakpoints, rates = [1.0, 3.0], [0.5, 2.0, 0.2]
+    frame = _generate(breakpoints, rates)
+
+    edges = [0.0, *breakpoints, float(frame["time"].max())]
+    for low, high, declared in zip(edges[:-1], edges[1:], rates):
+        estimate = _empirical_hazard(frame, low, high)
+        # The open-ended final interval is populated by the few survivors of the
+        # earlier ones, so it carries more Monte Carlo noise than the others.
+        rtol = 0.2 if high == edges[-1] else 0.05
+        np.testing.assert_allclose(
+            estimate,
+            declared,
+            rtol=rtol,
+            err_msg=f"hazard on [{low}, {high})",
+        )
+
+
+def test_many_breakpoints_stay_ordered() -> None:
+    """With four intervals, a rising specification must produce rising hazards."""
+    breakpoints, rates = [0.5, 1.0, 1.5], [0.2, 0.6, 1.8, 5.0]
+    frame = _generate(breakpoints, rates)
+
+    edges = [0.0, *breakpoints, float(frame["time"].max())]
+    estimates = [
+        _empirical_hazard(frame, low, high) for low, high in zip(edges[:-1], edges[1:])
+    ]
+
+    assert estimates == sorted(estimates), (
+        f"hazards {[round(e, 3) for e in estimates]} are not increasing, though "
+        f"the declared rates {rates} are"
+    )
+    for estimate, declared in zip(estimates[:-1], rates[:-1]):
+        np.testing.assert_allclose(estimate, declared, rtol=0.1)
+
+
+def test_covariates_scale_every_interval() -> None:
+    """A positive coefficient must raise the hazard in all intervals alike."""
+    breakpoints, rates = [1.0, 3.0], [0.5, 2.0, 0.2]
+
+    baseline = _generate(breakpoints, rates)
+    shifted = gen_piecewise_exponential(
+        n=_N,
+        breakpoints=breakpoints,
+        hazard_rates=rates,
+        betas=[0.5, 0.0],
+        covariate_dist="binary",
+        covariate_params={"p": 1.0},  # every subject has X0 == 1
+        model_cens="uniform",
+        cens_par=_NO_CENSORING,
+        seed=_SEED,
+    )
+
+    factor = float(np.exp(0.5))
+    for low, high in [(0.0, 1.0), (1.0, 3.0)]:
+        base = _empirical_hazard(baseline, low, high)
+        raised = _empirical_hazard(shifted, low, high)
+        np.testing.assert_allclose(raised / base, factor, rtol=0.1)


### PR DESCRIPTION
`gen_piecewise_exponential` draws the wrong event times whenever a specification has **two or more breakpoints**.

## What happens

The inversion loop walks the intervals, and when the event lands in a middle one it assigns the time and `break`s. But the trailing "subject outlived every interval" branch was written as a plain `if remaining_time > 0:` rather than the loop's `else:`, so it ran after the `break` as well and **overwrote the time just computed**, using the *last* hazard rate instead of the interval's own.

Measured over 40,000 subjects with `breakpoints=[1.0, 3.0]`, `hazard_rates=[0.5, 2.0, 0.2]`, `betas=[0, 0]` and no censoring — occurrence over exposure per interval:

| Interval | Declared | Before | After |
|---|---|---|---|
| `[0, 1)` | 0.5 | 0.501 ✓ | 0.501 ✓ |
| `[1, 3)` | 2.0 | **0.201** ✗ | 2.011 ✓ |
| `[3, ∞)` | 0.2 | **0.222** ✗ | 0.202 ✓ |

The middle interval came out at the final rate — a tenfold error — and the open-ended tail was inflated by the events displaced into it.

A single breakpoint was always correct: `range(1, 1)` is empty, so the middle loop never runs and the trailing branch is the right thing to do. That is why the existing shape-based tests never caught it, and why the two-rate examples in the old docs looked fine.

Same class of silent-wrong-data defect as the ones corrected in 1.3.0 and 2.0.0: the frame has the right columns, the right dtypes and the right row count, and the numbers in it are wrong.

## The fix

Turn the trailing branch into the loop's `else:`, so it runs only when the loop completed without breaking.

## Tests

`tests/test_piecewise_hazards.py` estimates the hazard on each interval and compares it against the declared rate:

- `test_single_breakpoint_hazards_match` — the case that already worked, so it stays working
- `test_middle_interval_uses_its_own_hazard` — the regression, asserting the middle rate is its own and *not* the last one
- `test_every_interval_matches_its_declared_hazard` — all three intervals
- `test_many_breakpoints_stay_ordered` — four intervals with rising rates
- `test_covariates_scale_every_interval` — `exp(beta)` scales every interval alike

Three of the five fail on the previous implementation and pass on this one. Verified by reverting `gen_surv/piecewise.py` alone and re-running.

## Note on reproducibility

This changes the data a given seed produces for multi-breakpoint specifications, as any sampler fix must. Worth a patch release, and worth a changelog line saying so.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `gen_piecewise_exponential` so events falling in middle intervals are drawn at the interval’s own hazard. Previously, the tail branch ran after a loop break and overwrote the computed time with one using the last hazard; now the tail branch runs only if the loop completes.

**Review and rollout**
- Implementation: replace the trailing if with the `for` loop’s `else`, limiting the tail calculation to survivors of all bounded intervals.
- Scope: affects specifications with two or more breakpoints; single-breakpoint behavior is unchanged.
- Tests: adds `tests/test_piecewise_hazards.py` to estimate hazards per interval; prior code fails three cases, this fix passes them.
- Migration: results for fixed seeds change when there are ≥2 breakpoints. Update baselines or snapshots as needed; no API changes.

<sup>Written for commit d73878888e1c5a80fcd5208cdaedae9ded5f219c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

