### PR TITLE
feat: add recurrent event generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@
 [pages-link]: https://diogoribeiro7.github.io/genSurvPy/
 [license-badge]: https://img.shields.io/pypi/l/gen_surv
 
-`gen_surv` generates synthetic time-to-event datasets from eleven models —
+`gen_surv` generates synthetic time-to-event datasets from twelve models —
 proportional hazards, accelerated failure time, competing risks, cure
-fractions, piecewise hazards and two illness-death processes — so you can test
-an estimator against parameters you chose yourself.
+fractions, piecewise hazards, recurrent events and two illness-death
+processes — so you can test an estimator against parameters you chose
+yourself.
 
 It is a Python port of the R package
 [genSurv](https://cran.r-project.org/package=genSurv), extended well past the
@@ -89,7 +90,7 @@ CoxPHFitter().fit(df, duration_col="time", event_col="status").params_
 That is the whole idea. Every column was produced by a mechanism you specified,
 so anything an estimator gets wrong is the estimator's fault.
 
-## The eleven models
+## The twelve models
 
 | `model=` | Family | Rows per subject |
 | --- | --- | --- |
@@ -104,6 +105,7 @@ so anything an estimator gets wrong is the estimator's fault.
 | `cmm` | Illness-death, counting-process intervals | 2 or 3 |
 | `thmm` | Illness-death, observed state panel | 2 or 3 |
 | `tdcm` | Cox with a time-dependent covariate | 1 |
+| `recurrent_events` | Repeated events: Andersen-Gill, PWP | 1 per at-risk interval |
 
 Every model has a page covering its parameters, the mathematics, a worked
 example, and a check that the parameters can be recovered from the data it

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ push, prompted by an external review of the R-derived generators:
 The highest-value work. The releases above fixed the defects that were found; the
 items here are about finding the ones that have not been.
 
-- [ ] **Distribution tests for the remaining generators.** Seven of eleven
+- [ ] **Distribution tests for the remaining generators.** Seven of twelve
       generators have no test that they produce their claimed distribution:
       `cphm`, the three AFT variants, `competing_risks_weibull`,
       `mixture_cure` and `piecewise_exponential`. Existing tests for these check
@@ -129,7 +129,12 @@ repetitive.
 
 Roughly in order of how often they are needed for realistic simulation studies:
 
-- [ ] **Recurrent events** — Andersen-Gill, and PWP in total-time and gap-time form
+- [x] **Recurrent events** — Andersen-Gill, and PWP in total-time and gap-time
+      form, over exponential, Weibull and Gompertz baselines. Returns
+      counting-process intervals with an `enum` column; distribution tests cover
+      the Poisson count under a constant intensity, the mean count against the
+      integrated baseline hazard for each family, the rate ratio against
+      `exp(beta)`, and the gap-time scaling from the stratum effects
 - [ ] **Frailty and clustered survival** — shared gamma and log-normal frailty
 - [ ] **Advanced censoring** — informative, interval, left-truncated and dependent
 - [ ] **Time-varying effects** — `beta(t)`, delayed effects, crossing hazards,

--- a/docs/api/generators.md
+++ b/docs/api/generators.md
@@ -35,3 +35,7 @@ the columns mean.
 ## Time-dependent covariates
 
 ::: gen_surv.tdcm
+
+## Recurrent events
+
+::: gen_surv.recurrent

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,7 +10,7 @@ or the [model pages](../models/index.md).
 
 | Name | Kind | Page |
 |---|---|---|
-| `generate` | dispatcher over all eleven models | [generate](generate.md) |
+| `generate` | dispatcher over all twelve models | [generate](generate.md) |
 | `gen_cphm` | Cox proportional hazards | [Generators](generators.md#gen_surv.cphm) |
 | `gen_aft_log_normal`, `gen_aft_weibull`, `gen_aft_log_logistic` | AFT models | [Generators](generators.md#gen_surv.aft) |
 | `gen_piecewise_exponential` | piecewise constant hazard | [Generators](generators.md#gen_surv.piecewise) |
@@ -19,6 +19,7 @@ or the [model pages](../models/index.md).
 | `gen_cmm` | illness-death, intervals | [Generators](generators.md#gen_surv.cmm) |
 | `gen_thmm` | illness-death, panel | [Generators](generators.md#gen_surv.thmm) |
 | `gen_tdcm` | time-dependent covariates | [Generators](generators.md#gen_surv.tdcm) |
+| `gen_recurrent_events` | recurrent events (Andersen-Gill, PWP) | [Generators](generators.md#gen_surv.recurrent) |
 | `runifcens`, `rexpocens`, `rweibcens`, `rlognormcens`, `rgammacens` | censoring samplers | [Censoring](censoring.md) |
 | `WeibullCensoring`, `LogNormalCensoring`, `GammaCensoring`, `CensoringModel` | class-based censoring | [Censoring](censoring.md) |
 | `sample_bivariate_distribution` | correlated draws | [Censoring](censoring.md#gen_surv.bivariate) |

--- a/docs/getting-started/schemas.md
+++ b/docs/getting-started/schemas.md
@@ -17,6 +17,7 @@ reference for that.
 | `cmm` | 2 or 3 | `id`, `start`, `stop`, `from_state`, `to_state`, `status`, `X0` |
 | `thmm` | 2 or 3 | `id`, `time`, `state`, `X0` |
 | `tdcm` | 1 | `id`, `start`, `stop`, `status`, `covariate`, `tdcov` |
+| `recurrent_events` | 1 per at-risk interval | `id`, `start`, `stop`, `status`, `enum`, `X0`, `X1`, … |
 
 !!! danger "Four traps"
 
@@ -203,6 +204,35 @@ censoring.
 
 This is the only model that names its covariate `covariate` rather than `X0`.
 
+### `recurrent_events`
+
+```text
+ id  start   stop  status  enum      X0      X1
+  0 0.0000 1.5050       1     1  0.3047 -1.0400
+  0 1.5050 1.6063       1     2  0.3047 -1.0400
+  0 1.6063 3.1723       1     3  0.3047 -1.0400
+  0 3.1723 5.0000       0     4  0.3047 -1.0400
+  2 0.0000 1.3893       1     1 -1.9510 -1.3022
+  2 1.3893 5.0000       0     2 -1.9510 -1.3022
+```
+
+One row per **at-risk interval**: the subject stays in the study after each
+event, so a subject with three events contributes four rows — three ending in an
+event, then the remainder of follow-up.
+
+| Column | dtype | Meaning |
+|---|---|---|
+| `id` | `int64` | subject, from 0 |
+| `start`, `stop` | `float64` | the interval over which the subject was at risk of its `enum`-th event |
+| `status` | `int64` | `1` if that event occurred at `stop`, `0` if follow-up ended first |
+| `enum` | `int64` | which event this interval is about, from 1 |
+| `X0`, `X1`, … | `float64` | covariates, constant within a subject |
+
+The intervals tile each subject's follow-up: `start` is 0 on the first row and
+equal to the previous `stop` afterwards, and the final row is censored — unless
+`max_events` ended follow-up at a capped event. Row counts are unbounded, so
+this is the model most likely to break code that assumes one row per subject.
+
 ## Writing code that survives a model change
 
 ```python
@@ -216,6 +246,7 @@ def subject_count(df):
     return df["id"].nunique() if "id" in df else len(df)
 ```
 
-If you need one function across all eleven, branch on the columns present
+If you need one function across all twelve, branch on the columns present
 rather than on the model name — `cmm` is the frame with `from_state`, `thmm` the
-one with `state` and no `status`, `mixture_cure` the one with `cured`.
+one with `state` and no `status`, `mixture_cure` the one with `cured`, and
+`recurrent_events` the one with `enum`.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -27,9 +27,10 @@ directory is not on `PATH`.
 gen_surv dataset MODEL [OPTIONS]
 ```
 
-`MODEL` is any of the eleven names — `cphm`, `cmm`, `tdcm`, `thmm`, `aft_ln`,
+`MODEL` is any of the twelve names — `cphm`, `cmm`, `tdcm`, `thmm`, `aft_ln`,
 `aft_weibull`, `aft_log_logistic`, `competing_risks`,
-`competing_risks_weibull`, `mixture_cure`, `piecewise_exponential`.
+`competing_risks_weibull`, `mixture_cure`, `piecewise_exponential`,
+`recurrent_events`.
 
 Writes CSV to the path given by `-o`, or to stdout when it is omitted:
 
@@ -58,6 +59,12 @@ gen_surv dataset aft_ln --n 500 --beta 0.5 --beta -0.3 --sigma 1.0 | head -5
 | `--shape-params`, `--scale-params` | — | `competing_risks_weibull` — repeat |
 | `--cure-fraction`, `--baseline-hazard` | — | `mixture_cure` |
 | `--breakpoints`, `--hazard-rates` | — | `piecewise_exponential` — repeat |
+| `--process` | `ag` | `recurrent_events` — `ag`, `pwp_tt` or `pwp_gt` |
+| `--baseline` | `exponential` | `recurrent_events` — `exponential`, `weibull` or `gompertz` |
+| `--rate` | `1.0` | `recurrent_events` — baseline rate, for exponential and Gompertz |
+| `--stratum-effects` | — | `recurrent_events` — per-event factors, repeat the flag |
+| `--max-events` | `None` | `recurrent_events` — stop a subject after this many events |
+| `--followup-time` | `10.0` | `recurrent_events` — administrative end of follow-up |
 | `--seed` | `None` | all models |
 | `-o` | stdout | output CSV path |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # gen_surv
 
 **Simulate survival data with a known truth.** `gen_surv` generates synthetic
-time-to-event datasets from eleven models — proportional hazards, accelerated
-failure time, competing risks, cure fractions, piecewise hazards and two
-illness-death processes — so you can test an estimator against parameters you
-chose yourself.
+time-to-event datasets from twelve models — proportional hazards, accelerated
+failure time, competing risks, cure fractions, piecewise hazards, recurrent
+events and two illness-death processes — so you can test an estimator against
+parameters you chose yourself.
 
 It is a Python port of the R package
 [genSurv](https://cran.r-project.org/package=genSurv), extended well past the
@@ -72,7 +72,7 @@ specified.
 
 </div>
 
-## The eleven models
+## The twelve models
 
 | `model=` | Family | Returns | Page |
 |---|---|---|---|
@@ -87,6 +87,7 @@ specified.
 | `cmm` | Illness-death, counting-process intervals | two or three rows per subject | [CMM](models/cmm.md) |
 | `thmm` | Illness-death, observed state panel | two or three rows per subject | [THMM](models/thmm.md) |
 | `tdcm` | Cox with a time-dependent covariate | one row per subject | [TDCM](models/tdcm.md) |
+| `recurrent_events` | Repeated events per subject (AG, PWP) | one row per at-risk interval | [Recurrent events](models/recurrent-events.md) |
 
 Not sure which one you need? [Choosing a model](models/index.md) walks through
 the decision.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,6 +1,6 @@
 # Choosing a model
 
-Eleven generators, grouped by the question they answer.
+Twelve generators, grouped by the question they answer.
 
 ## Decide by what you are testing
 
@@ -14,6 +14,7 @@ Eleven generators, grouped by the question they answer.
 | An illness-death process, as risk intervals | [`cmm`](cmm.md) | Counting-process rows, one per transition at risk |
 | An illness-death process, as observed states | [`thmm`](thmm.md) | Panel of state observations at times |
 | An exposure that changes during follow-up | [`tdcm`](tdcm.md) | Cox model with a covariate that switches value mid-follow-up |
+| The same event happening more than once | [`recurrent_events`](recurrent-events.md) | Andersen-Gill and Prentice-Williams-Peterson processes |
 
 ## Decide by hazard shape
 
@@ -32,6 +33,7 @@ flowchart TD
     D --> D2["aft_log_logistic<br/>unimodal hazard"]
     E --> E1["cmm / thmm<br/>illness-death"]
     E --> E2["tdcm<br/>covariate changes, not the state"]
+    E --> E3["recurrent_events<br/>the same event, repeatedly"]
 ```
 
 ## The parameter each model is "about"
@@ -48,6 +50,7 @@ the short version of what to feed an estimator:
 | `mixture_cure` | `cure_fraction` | `cure_fraction_estimate`, or the plateau of the KM curve |
 | `cmm` / `thmm` | `rate` per transition | Transitions divided by time at risk in the origin state |
 | `tdcm` | `beta` — baseline and time-dependent effects | Cox model on the `(start, stop]` frame |
+| `recurrent_events` | `betas`, and `stratum_effects` for PWP | Time-varying Cox on the `(start, stop]` frame |
 
 ## They all share these arguments
 
@@ -96,8 +99,8 @@ generate(model="weibull")
 ```text
 ChoiceError: Argument 'model' must be one of 'aft_ln', 'aft_log_logistic',
 'aft_weibull', 'cmm', 'competing_risks', 'competing_risks_weibull', 'cphm',
-'mixture_cure', 'piecewise_exponential', 'tdcm', 'thmm'; got 'weibull' of
-type str. Choose a valid option.
+'mixture_cure', 'piecewise_exponential', 'recurrent_events', 'tdcm', 'thmm';
+got 'weibull' of type str. Choose a valid option.
 ```
 
 Model-specific validation says which model it was checking, which matters when

--- a/docs/models/recurrent-events.md
+++ b/docs/models/recurrent-events.md
@@ -1,0 +1,288 @@
+# Recurrent events
+
+`model="recurrent_events"` — the same event happening repeatedly to the same
+subject: hospital readmissions, asthma attacks, equipment failures, infections.
+
+Unlike every other generator here, a subject does not leave the study when the
+event occurs. It stays at risk, and the frame records one interval per event
+plus the remainder of follow-up.
+
+## Three processes
+
+The `process` argument picks how the intensity relates to the event history,
+matching the three models the data is usually analysed with.
+
+=== "`ag` — Andersen-Gill"
+
+    $$
+    \lambda(t \mid X) = h_0(t)\exp(X^\top\beta)
+    $$
+
+    The intensity **ignores the event history**: a subject's fourth event is no
+    more or less likely than its first, given the same covariates and time.
+    Formally a non-homogeneous Poisson process. The clock runs forward from
+    entry.
+
+    Use it when events are exchangeable and the covariate effect is what you
+    are testing.
+
+=== "`pwp_tt` — PWP, total time"
+
+    $$
+    \lambda_k(t \mid X) = h_0(t)\, s_k \exp(X^\top\beta)
+    $$
+
+    The intensity of the $k$-th event is scaled by $s_k$, so a second event can
+    be more likely than a first. The clock still runs forward from entry.
+
+    Use it when the risk changes with how many events have happened, but the
+    baseline is a function of time in the study.
+
+=== "`pwp_gt` — PWP, gap time"
+
+    $$
+    \lambda_k(w \mid X) = h_0(w)\, s_k \exp(X^\top\beta),
+    \qquad w = t - t_{k-1}
+    $$
+
+    As `pwp_tt`, but **the clock resets after every event**, so the baseline is a
+    function of time since the previous event.
+
+    Use it when what matters is the waiting time between events rather than
+    elapsed study time.
+
+Events are drawn by inversion. With intensity $h_0(t)e^{\eta}s_k$, the
+cumulative intensity between consecutive events is $\mathrm{Exponential}(1)$, so
+the next event solves
+
+$$
+H_0(t) = H_0(t_{k-1}) + \frac{E}{e^{\eta}s_k}
+\quad\text{(forward clock)},
+\qquad
+H_0(w) = \frac{E}{e^{\eta}s_k}
+\quad\text{(reset clock)}.
+$$
+
+## Baseline hazards
+
+| `baseline` | $h_0(t)$ | Parameters | Shape |
+|---|---|---|---|
+| `exponential` | $\lambda$ | `rate` | constant |
+| `weibull` | $\dfrac{\rho}{\sigma}\left(\dfrac{t}{\sigma}\right)^{\rho-1}$ | `shape`, `scale` | monotone |
+| `gompertz` | $a e^{bt}$ | `rate`, `shape` | exponentially rising or falling |
+
+`baseline_params` accepts only the keys belonging to the chosen family; a
+misspelt one raises rather than silently leaving the default in place. A
+Gompertz `shape` may be **negative**, which gives a declining hazard and a
+finite total hazard, so events eventually stop.
+
+## Parameters
+
+```python
+gen_recurrent_events(n, process="ag", baseline="exponential",
+                     baseline_params=None, betas=None, n_covariates=2,
+                     covariate_dist="normal", covariate_params=None,
+                     stratum_effects=None, max_events=None,
+                     followup_time=10.0, model_cens="uniform",
+                     cens_par=20.0, seed=None)
+```
+
+| Parameter | Type | Default | Meaning |
+|---|---|---|---|
+| `n` | `int` | — | number of subjects — **not** the number of rows |
+| `process` | `"ag"` \| `"pwp_tt"` \| `"pwp_gt"` | `"ag"` | the event process, as above |
+| `baseline` | `"exponential"` \| `"weibull"` \| `"gompertz"` | `"exponential"` | baseline hazard family |
+| `baseline_params` | `dict` \| `None` | `None` | that family's parameters; defaults filled in |
+| `betas` | `list[float]` \| `None` | `None` | coefficients on the log intensity; **drawn at random when omitted** |
+| `n_covariates` | `int` | `2` | covariate count when `betas` is omitted |
+| `covariate_dist` | `"normal"` \| `"uniform"` \| `"binary"` | `"normal"` | see [Covariates](../guides/covariates.md) |
+| `covariate_params` | `dict` \| `None` | `None` | that distribution's parameters |
+| `stratum_effects` | `list[float]` \| `None` | `None` | per-event intensity factors, for the PWP processes |
+| `max_events` | `int` \| `None` | `None` | stop following a subject after this many events |
+| `followup_time` | `float` | `10.0` | administrative end of follow-up, for everyone |
+| `model_cens` | `"uniform"` \| `"exponential"` | `"uniform"` | random dropout, on top of `followup_time` |
+| `cens_par` | `float` | `20.0` | dropout parameter |
+| `seed` | `int` \| `Generator` \| `None` | `None` | reproducibility |
+
+`stratum_effects` applies its **last entry to all later events**, so
+`[1.0, 2.0]` reads as "the first event at the baseline rate, every subsequent
+one at twice that".
+
+!!! warning "`stratum_effects` with `process="ag"` raises"
+
+    An Andersen-Gill intensity cannot depend on the event number — that is what
+    distinguishes it from PWP. Applying the effects anyway would produce PWP
+    data under an AG label, and ignoring them would discard an argument you
+    clearly meant, so the combination is rejected:
+
+    ```text
+    ParameterError: Invalid value for 'stratum_effects': [1.0, 2.0] (type list).
+    is not applicable to process='ag', whose intensity cannot depend on the
+    event number; use process='pwp_tt' or process='pwp_gt'.
+    ```
+
+## Example
+
+```python
+from gen_surv import generate
+
+df = generate(model="recurrent_events", n=3,
+              baseline_params={"rate": 0.5}, betas=[0.4, -0.2],
+              followup_time=5.0, cens_par=1e9, seed=42)
+print(df.round(4))
+```
+
+```text
+ id  start   stop  status  enum      X0      X1
+  0 0.0000 1.5050       1     1  0.3047 -1.0400
+  0 1.5050 1.6063       1     2  0.3047 -1.0400
+  0 1.6063 3.1723       1     3  0.3047 -1.0400
+  0 3.1723 5.0000       0     4  0.3047 -1.0400
+  1 0.0000 0.6918       1     1  0.7505  0.9406
+  1 0.6918 2.8938       1     2  0.7505  0.9406
+  1 2.8938 3.1687       1     3  0.7505  0.9406
+  1 3.1687 3.3325       1     4  0.7505  0.9406
+  1 3.3325 3.8960       1     5  0.7505  0.9406
+  1 3.8960 5.0000       0     6  0.7505  0.9406
+  2 0.0000 1.3893       1     1 -1.9510 -1.3022
+  2 1.3893 5.0000       0     2 -1.9510 -1.3022
+```
+
+Three subjects, twelve rows, three and five and one events.
+
+| Column | dtype | Meaning |
+|---|---|---|
+| `id` | `int64` | subject, from 0 |
+| `start`, `stop` | `float64` | the interval over which the subject was at risk of its `enum`-th event |
+| `status` | `int64` | `1` if that event occurred at `stop`, `0` if follow-up ended first |
+| `enum` | `int64` | which event this interval is about, from 1 |
+| `X0`, `X1`, … | `float64` | covariates, constant within a subject |
+
+The intervals **tile each subject's follow-up**: `start` is 0 for the first row
+and equal to the previous `stop` thereafter, and the last row of every subject
+is censored. Counting subjects means `df["id"].nunique()`, never `len(df)`.
+
+Counting events:
+
+```python
+df.groupby("id")["status"].sum()      # events per subject
+df["status"].sum()                    # events in total
+```
+
+## Check: does a Cox model recover the coefficients?
+
+The frame is already in the `(start, stop]` layout that a time-varying Cox
+model expects, so it goes straight into `CoxTimeVaryingFitter`:
+
+```python
+from gen_surv import generate
+from lifelines import CoxTimeVaryingFitter
+
+df = generate(model="recurrent_events", n=4000,
+              baseline_params={"rate": 0.5}, betas=[0.4, -0.2],
+              followup_time=5.0, cens_par=1e9, seed=7)
+
+fit = CoxTimeVaryingFitter().fit(df, id_col="id", start_col="start",
+                                 stop_col="stop", event_col="status")
+print(fit.summary[["coef", "se(coef)"]].round(3))
+```
+
+```text
+            coef  se(coef)
+covariate
+enum      -0.004     0.007
+X0         0.399     0.011
+X1        -0.201     0.010
+```
+
+`X0` and `X1` come back at 0.399 and −0.201 against a truth of 0.4 and −0.2.
+And because `enum` was left in the frame, it is fitted too — its coefficient of
+−0.004 is the Andersen-Gill assumption showing up in the data: **the event
+number carries no information**, which is exactly what `process="ag"` promises.
+Generate with `pwp_tt` instead and that coefficient stops being zero.
+
+## Check: the counting process itself
+
+With no covariate effect, the expected number of events by time $T$ is the
+integrated baseline hazard, $\mathbb{E}[N(T)] = H_0(T)$:
+
+```python
+counts = df.groupby("id")["status"].sum()
+counts.mean(), counts.var()
+```
+
+| Baseline | Parameters | $H_0(5)$ | Observed mean |
+|---|---|---|---|
+| `exponential` | `rate=0.5` | 2.500 | 2.484 |
+| `weibull` | `shape=1.5, scale=2.0` | 3.953 | 3.923 |
+| `gompertz` | `rate=0.3, shape=0.2` | 2.577 | 2.562 |
+
+(20,000 subjects, `betas=[0, 0]`, no dropout.)
+
+For the exponential baseline the process is Poisson, so the **variance should
+equal the mean** — measured at 2.499 against a mean of 2.484. A generator that
+merely got the average right would fail that check.
+
+## Choosing between the clocks
+
+The clock only matters when the baseline is not constant. A constant hazard is
+memoryless, so `ag` and `pwp_gt` produce identical data:
+
+```python
+common = dict(n=300, baseline_params={"rate": 0.8}, betas=[0.2, -0.1],
+              followup_time=6.0, seed=9)
+
+generate(model="recurrent_events", process="ag", **common)
+generate(model="recurrent_events", process="pwp_gt", **common)   # the same frame
+```
+
+With a rising Weibull hazard they diverge sharply. On a forward clock the
+hazard keeps climbing with time in the study; on a reset clock every event puts
+the subject back at the start of the curve:
+
+| `shape=2.0, scale=2.0`, `followup_time=6` | Mean events per subject |
+|---|---|
+| `process="ag"` (forward clock) | 7.18 |
+| `process="pwp_gt"` (reset clock) | 2.53 |
+
+## Stratum effects
+
+```python
+df = generate(model="recurrent_events", n=20000, process="pwp_gt",
+              baseline_params={"rate": 1.0}, betas=[0.0, 0.0],
+              stratum_effects=[1.0, 2.0], followup_time=20.0,
+              cens_par=1e9, seed=7)
+
+events = df[df["status"] == 1].assign(gap=lambda d: d["stop"] - d["start"])
+events.groupby(events["enum"] > 1)["gap"].mean()
+```
+
+```text
+enum > 1
+False    0.982      # first events: mean gap 1 / 1.0
+True     0.488      # later events:  mean gap 1 / 2.0
+```
+
+Doubling the intensity halves the mean gap, as it should.
+
+## Ending follow-up
+
+Three mechanisms, applied together:
+
+| Mechanism | Argument | Effect |
+|---|---|---|
+| Administrative | `followup_time` | everyone's follow-up ends here |
+| Random dropout | `model_cens`, `cens_par` | subject-specific, on top of the above |
+| Event cap | `max_events` | the subject leaves after this many events |
+
+`max_events` ends follow-up **at the capped event**, so a capped subject has no
+trailing censored row. That keeps the data honest: the alternative — recording
+further at-risk time while suppressing the events in it — would look like a
+subject that stopped having events.
+
+## Related
+
+- [Output schemas](../getting-started/schemas.md#recurrent_events) — the counting-process layout
+- [Illness-death, intervals (CMM)](cmm.md) — the same layout for transitions between states rather than repeats of one event
+- [Competing risks](competing-risks.md) — several kinds of event, each occurring at most once
+- API: [`gen_recurrent_events`](../api/generators.md#gen_surv.recurrent.gen_recurrent_events)

--- a/gen_surv/__init__.py
+++ b/gen_surv/__init__.py
@@ -25,6 +25,7 @@ from .export import export_dataset
 from .interface import generate
 from .mixture import cure_fraction_estimate, gen_mixture_cure
 from .piecewise import gen_piecewise_exponential
+from .recurrent import gen_recurrent_events
 from .sklearn_adapter import GenSurvDataGenerator
 from .tdcm import gen_tdcm
 from .thmm import gen_thmm
@@ -74,6 +75,7 @@ __all__ = [
     "gen_mixture_cure",
     "cure_fraction_estimate",
     "gen_piecewise_exponential",
+    "gen_recurrent_events",
     # Helper functions
     "sample_bivariate_distribution",
     "runifcens",

--- a/gen_surv/cli.py
+++ b/gen_surv/cli.py
@@ -20,7 +20,7 @@ def dataset(
     model: str = typer.Argument(
         ...,
         help=(
-            "Model to simulate [cphm, cmm, tdcm, thmm, aft_ln, aft_weibull, aft_log_logistic, competing_risks, competing_risks_weibull, mixture_cure, piecewise_exponential]"
+            "Model to simulate [cphm, cmm, tdcm, thmm, aft_ln, aft_weibull, aft_log_logistic, competing_risks, competing_risks_weibull, mixture_cure, piecewise_exponential, recurrent_events]"
         ),
     ),
     n: int = typer.Option(100, help="Number of samples"),
@@ -64,6 +64,29 @@ def dataset(
     ),
     hazard_rates: List[float] = typer.Option(
         [], help="Hazard rates for piecewise exponential model"
+    ),
+    process: str = typer.Option(
+        "ag",
+        help=(
+            "Recurrent event process: 'ag' (Andersen-Gill), 'pwp_tt' or "
+            "'pwp_gt' (Prentice-Williams-Peterson in total or gap time)"
+        ),
+    ),
+    baseline: str = typer.Option(
+        "exponential",
+        help="Baseline hazard for recurrent events: 'exponential', 'weibull' or 'gompertz'",
+    ),
+    rate: float = typer.Option(
+        1.0, help="Baseline rate (exponential and Gompertz recurrent events)"
+    ),
+    stratum_effects: List[float] = typer.Option(
+        [], help="Per-event intensity factors for the PWP recurrent processes"
+    ),
+    max_events: int | None = typer.Option(
+        None, help="Stop following a subject after this many recurrent events"
+    ),
+    followup_time: float = typer.Option(
+        10.0, help="Administrative end of follow-up for recurrent events"
     ),
     seed: int | None = typer.Option(None, help="Random seed for reproducibility"),
     output: str | None = typer.Option(
@@ -148,6 +171,31 @@ def dataset(
         kwargs["breakpoints"] = _val(breakpoints)
         kwargs["hazard_rates"] = _val(hazard_rates)
         kwargs["betas"] = _val(beta)
+
+    elif model_str == "recurrent_events":
+        baseline_str: str = _val(baseline)
+        kwargs["process"] = _val(process)
+        kwargs["baseline"] = baseline_str
+        kwargs["followup_time"] = _val(followup_time)
+
+        # Only the keys that belong to the chosen baseline: the generator
+        # rejects the others rather than ignoring them.
+        if baseline_str == "exponential":
+            kwargs["baseline_params"] = {"rate": _val(rate)}
+        elif baseline_str == "weibull":
+            kwargs["baseline_params"] = {
+                "shape": _val(shape),
+                "scale": _val(scale),
+            }
+        elif baseline_str == "gompertz":
+            kwargs["baseline_params"] = {"rate": _val(rate), "shape": _val(shape)}
+
+        if _val(beta):
+            kwargs["betas"] = _val(beta)
+        if _val(stratum_effects):
+            kwargs["stratum_effects"] = _val(stratum_effects)
+        if _val(max_events) is not None:
+            kwargs["max_events"] = _val(max_events)
 
     # Generate the data
     try:

--- a/gen_surv/interface.py
+++ b/gen_surv/interface.py
@@ -17,6 +17,7 @@ from gen_surv.competing_risks import gen_competing_risks, gen_competing_risks_we
 from gen_surv.cphm import gen_cphm
 from gen_surv.mixture import gen_mixture_cure
 from gen_surv.piecewise import gen_piecewise_exponential
+from gen_surv.recurrent import gen_recurrent_events
 from gen_surv.tdcm import gen_tdcm
 from gen_surv.thmm import gen_thmm
 
@@ -35,6 +36,7 @@ ModelType = Literal[
     "competing_risks_weibull",
     "mixture_cure",
     "piecewise_exponential",
+    "recurrent_events",
 ]
 
 
@@ -55,6 +57,7 @@ _model_map: Dict[ModelType, DataGenerator] = {
     "competing_risks_weibull": gen_competing_risks_weibull,
     "mixture_cure": gen_mixture_cure,
     "piecewise_exponential": gen_piecewise_exponential,
+    "recurrent_events": gen_recurrent_events,
 }
 
 
@@ -67,7 +70,7 @@ def generate(model: ModelType, **kwargs: object) -> pd.DataFrame:
         Name of the generator to run. Must be one of ``cphm``, ``cmm``,
         ``tdcm``, ``thmm``, ``aft_ln``, ``aft_weibull``, ``aft_log_logistic``,
         ``competing_risks``, ``competing_risks_weibull``, ``mixture_cure``,
-        or ``piecewise_exponential``.
+        ``piecewise_exponential`` or ``recurrent_events``.
     **kwargs
         Arguments forwarded to the chosen generator. These vary by model.
 
@@ -83,6 +86,8 @@ def generate(model: ModelType, **kwargs: object) -> pd.DataFrame:
         - mixture_cure: n, cure_fraction, baseline_hazard, betas_survival,
           betas_cure, etc.
         - piecewise_exponential: n, breakpoints, hazard_rates, betas, etc.
+        - recurrent_events: n, process, baseline, baseline_params, betas,
+          stratum_effects, followup_time, etc.
 
     Returns
     -------

--- a/gen_surv/recurrent.py
+++ b/gen_surv/recurrent.py
@@ -1,0 +1,327 @@
+"""Recurrent event data generation.
+
+Subjects may experience the same event repeatedly during follow-up. The three
+processes here correspond to the models the data is usually analysed with:
+
+``ag``
+    Andersen-Gill. The intensity depends on the covariates but not on how many
+    events have already happened, and the clock runs forward from entry. A
+    non-homogeneous Poisson process.
+``pwp_tt``
+    Prentice-Williams-Peterson in total time. As Andersen-Gill, but the
+    intensity is scaled by a factor specific to the event number, so the risk of
+    a second event may differ from the risk of a first. The clock still runs
+    forward from entry.
+``pwp_gt``
+    Prentice-Williams-Peterson in gap time. As ``pwp_tt``, but the clock resets
+    after every event, so the baseline hazard is a function of time since the
+    previous event rather than time since entry.
+
+All three return counting-process intervals, the canonical layout for
+transition data in this package.
+"""
+
+from typing import Literal, Sequence
+
+import numpy as np
+import pandas as pd
+from numpy.random import Generator
+from numpy.typing import NDArray
+
+from ._covariates import generate_covariates, prepare_betas, set_covariate_params
+from ._rng import RandomStateLike, resolve_rng
+from .censoring import CensoringFunc, rexpocens, runifcens
+from .validation import validate_gen_recurrent_events_inputs
+
+Process = Literal["ag", "pwp_tt", "pwp_gt"]
+Baseline = Literal["exponential", "weibull", "gompertz"]
+
+_COLUMNS = ["id", "start", "stop", "status", "enum"]
+
+# Default parameters per baseline, used when ``baseline_params`` is omitted.
+_BASELINE_DEFAULTS: dict[str, dict[str, float]] = {
+    "exponential": {"rate": 1.0},
+    "weibull": {"shape": 1.5, "scale": 1.0},
+    "gompertz": {"rate": 0.5, "shape": 0.2},
+}
+
+
+def _cumulative_hazard(t: float, baseline: Baseline, params: dict[str, float]) -> float:
+    """Baseline cumulative hazard ``H0(t)``.
+
+    Parameters
+    ----------
+    t : float
+        Time at which to evaluate, non-negative.
+    baseline : {"exponential", "weibull", "gompertz"}
+        Baseline hazard family.
+    params : dict[str, float]
+        Parameters of that family, already completed with defaults.
+
+    Returns
+    -------
+    float
+        The integrated baseline hazard from 0 to ``t``.
+    """
+    if baseline == "exponential":
+        return params["rate"] * t
+    if baseline == "weibull":
+        return float((t / params["scale"]) ** params["shape"])
+    # Gompertz: h0(t) = rate * exp(shape * t)
+    return float(params["rate"] / params["shape"] * (np.expm1(params["shape"] * t)))
+
+
+def _inverse_cumulative_hazard(
+    value: float, baseline: Baseline, params: dict[str, float]
+) -> float:
+    """Invert :func:`_cumulative_hazard`, returning ``t`` such that ``H0(t) == value``.
+
+    Parameters
+    ----------
+    value : float
+        A value of the cumulative hazard, non-negative.
+    baseline : {"exponential", "weibull", "gompertz"}
+        Baseline hazard family.
+    params : dict[str, float]
+        Parameters of that family, already completed with defaults.
+
+    Returns
+    -------
+    float
+        The time at which the cumulative hazard reaches ``value``. ``inf`` when
+        a Gompertz hazard with a negative shape never reaches it, which is a
+        real property of that family rather than an error.
+    """
+    if baseline == "exponential":
+        return value / params["rate"]
+    if baseline == "weibull":
+        return float(params["scale"] * value ** (1.0 / params["shape"]))
+    # Gompertz with shape < 0 has a finite total hazard, so large values are
+    # never reached and the subject simply has no further events.
+    inner = 1.0 + params["shape"] * value / params["rate"]
+    if inner <= 0.0:
+        return float("inf")
+    return float(np.log(inner) / params["shape"])
+
+
+def _stratum_factor(stratum_effects: Sequence[float] | None, enum: int) -> float:
+    """Return the intensity multiplier for the ``enum``-th event.
+
+    The last supplied effect applies to every later event, so a two-element
+    sequence describes "first event, and all subsequent ones".
+    """
+    if not stratum_effects:
+        return 1.0
+    index = min(enum, len(stratum_effects)) - 1
+    return float(stratum_effects[index])
+
+
+def _subject_rows(
+    subject: int,
+    eta: float,
+    end: float,
+    process: Process,
+    baseline: Baseline,
+    params: dict[str, float],
+    stratum_effects: Sequence[float] | None,
+    max_events: int | None,
+    rng: Generator,
+) -> list[tuple[int, float, float, int, int]]:
+    """Generate one subject's counting-process intervals.
+
+    Events are drawn by inversion: with intensity ``h0(t) exp(eta) s_k``, the
+    cumulative hazard between consecutive events is Exponential(1), so the next
+    event solves ``H0(t) = H0(t_prev) + E / (exp(eta) s_k)`` on a forward clock,
+    and ``H0(w) = E / (exp(eta) s_k)`` on a clock that resets.
+    """
+    rows: list[tuple[int, float, float, int, int]] = []
+    linear = float(np.exp(eta))
+    current = 0.0
+    enum = 1
+
+    while True:
+        factor = linear * _stratum_factor(stratum_effects, enum)
+        draw = float(rng.exponential())
+        consumed = draw / factor
+
+        if process == "pwp_gt":
+            gap = _inverse_cumulative_hazard(consumed, baseline, params)
+            candidate = current + gap
+        else:
+            target = _cumulative_hazard(current, baseline, params) + consumed
+            candidate = _inverse_cumulative_hazard(target, baseline, params)
+
+        if not np.isfinite(candidate) or candidate >= end:
+            break
+
+        rows.append((subject, current, candidate, 1, enum))
+        current = candidate
+
+        if max_events is not None and enum >= max_events:
+            # Follow-up stops with the capped event: the subject leaves the
+            # study rather than remaining at risk with its events suppressed.
+            return rows
+
+        enum += 1
+
+    # The remainder of follow-up, during which no further event occurred.
+    rows.append((subject, current, end, 0, enum))
+    return rows
+
+
+def gen_recurrent_events(
+    n: int,
+    process: Process = "ag",
+    baseline: Baseline = "exponential",
+    baseline_params: dict[str, float] | None = None,
+    betas: Sequence[float] | None = None,
+    n_covariates: int = 2,
+    covariate_dist: Literal["normal", "uniform", "binary"] = "normal",
+    covariate_params: dict[str, float] | None = None,
+    stratum_effects: Sequence[float] | None = None,
+    max_events: int | None = None,
+    followup_time: float = 10.0,
+    model_cens: Literal["uniform", "exponential"] = "uniform",
+    cens_par: float = 20.0,
+    seed: RandomStateLike = None,
+) -> pd.DataFrame:
+    """Generate recurrent event data in counting-process form.
+
+    Parameters
+    ----------
+    n : int
+        Number of subjects. Each contributes one row per at-risk interval, so
+        the frame is longer than ``n``.
+    process : {"ag", "pwp_tt", "pwp_gt"}
+        Event process. ``ag`` is Andersen-Gill, whose intensity ignores the
+        event history. ``pwp_tt`` and ``pwp_gt`` are Prentice-Williams-Peterson
+        in total and gap time, whose intensity is scaled per event number by
+        ``stratum_effects``; ``pwp_gt`` additionally resets the clock after each
+        event.
+    baseline : {"exponential", "weibull", "gompertz"}
+        Baseline hazard family. Exponential is constant, Weibull is monotone,
+        Gompertz is exponentially increasing or decreasing.
+    baseline_params : dict[str, float], optional
+        Parameters of the baseline. ``{"rate"}`` for exponential,
+        ``{"shape", "scale"}`` for Weibull, ``{"rate", "shape"}`` for Gompertz.
+        Defaults are filled in when omitted.
+    betas : Sequence[float], optional
+        Coefficients acting on the log intensity, one per covariate. Drawn at
+        random when omitted, which is convenient for a smoke test and unusable
+        for validation.
+    n_covariates : int
+        Number of covariates when ``betas`` is not supplied.
+    covariate_dist : {"normal", "uniform", "binary"}
+        Distribution the covariates are drawn from.
+    covariate_params : dict[str, float], optional
+        Parameters of that distribution. Defaults are filled in when omitted.
+    stratum_effects : Sequence[float], optional
+        Multiplicative intensity factors by event number, for the two PWP
+        processes. The final entry applies to all later events, so
+        ``[1.0, 2.0]`` means "first event at the baseline rate, every subsequent
+        one at twice that". Supplying it with ``process="ag"`` raises, because
+        an Andersen-Gill intensity cannot depend on the event number.
+    max_events : int, optional
+        Stop following a subject once it has this many events. ``None`` places
+        no cap.
+    followup_time : float
+        Administrative end of follow-up, applied to every subject.
+    model_cens : {"uniform", "exponential"}
+        Random dropout mechanism, applied on top of ``followup_time``.
+    cens_par : float
+        Parameter of the dropout distribution: the upper bound for ``uniform``,
+        the mean for ``exponential``.
+    seed : int or numpy.random.Generator, optional
+        Seed or generator for reproducibility.
+
+    Returns
+    -------
+    pd.DataFrame
+        Counting-process intervals with columns ``["id", "start", "stop",
+        "status", "enum", "X0", ..., "Xp"]``. Each row is the interval over
+        which a subject was at risk of its ``enum``-th event; ``status`` is 1 if
+        that event occurred at ``stop`` and 0 if follow-up ended first. Every
+        subject contributes at least one row, and intervals are contiguous
+        within a subject.
+
+    Raises
+    ------
+    ValidationError
+        If any parameter is outside its allowed range.
+
+    Examples
+    --------
+    >>> from gen_surv.recurrent import gen_recurrent_events
+    >>> df = gen_recurrent_events(
+    ...     n=50,
+    ...     process="ag",
+    ...     baseline_params={"rate": 0.5},
+    ...     betas=[0.4, -0.2],
+    ...     followup_time=5.0,
+    ...     seed=42,
+    ... )
+    >>> list(df.columns)
+    ['id', 'start', 'stop', 'status', 'enum', 'X0', 'X1']
+    """
+    validate_gen_recurrent_events_inputs(
+        n=n,
+        process=process,
+        baseline=baseline,
+        baseline_params=baseline_params,
+        n_covariates=n_covariates,
+        stratum_effects=stratum_effects,
+        max_events=max_events,
+        followup_time=followup_time,
+        model_cens=model_cens,
+        cens_par=cens_par,
+    )
+
+    rng = resolve_rng(seed)
+
+    params = dict(_BASELINE_DEFAULTS[baseline])
+    params.update(baseline_params or {})
+
+    covariate_params = set_covariate_params(covariate_dist, covariate_params)
+    coefficients, n_covariates = prepare_betas(betas, n_covariates, rng, name="betas")
+    covariates: NDArray[np.float64] = generate_covariates(
+        n, n_covariates, covariate_dist, covariate_params, rng
+    )
+    eta = covariates @ coefficients
+
+    rfunc: CensoringFunc = runifcens if model_cens == "uniform" else rexpocens
+    dropout = rfunc(n, cens_par, rng)
+    ends = np.minimum(dropout, followup_time)
+
+    # The event history of one subject depends on its own previous draws, so
+    # this loop is over subjects rather than over a vectorised array.
+    records: list[tuple[int, float, float, int, int]] = []
+    for subject in range(n):
+        records.extend(
+            _subject_rows(
+                subject=subject,
+                eta=float(eta[subject]),
+                end=float(ends[subject]),
+                process=process,
+                baseline=baseline,
+                params=params,
+                stratum_effects=stratum_effects,
+                max_events=max_events,
+                rng=rng,
+            )
+        )
+
+    data = pd.DataFrame(records, columns=_COLUMNS)
+    data = data.astype(
+        {
+            "id": "int64",
+            "start": "float64",
+            "stop": "float64",
+            "status": "int64",
+            "enum": "int64",
+        }
+    )
+
+    for j in range(n_covariates):
+        data[f"X{j}"] = covariates[data["id"].to_numpy(), j]
+
+    return data.reset_index(drop=True)

--- a/gen_surv/validation.py
+++ b/gen_surv/validation.py
@@ -538,3 +538,99 @@ def validate_gen_mixture_inputs(
             cure_fraction,
             "must be between 0 and 1 (exclusive). Try a value like 0.5",
         )
+
+
+_RECURRENT_PROCESSES = {"ag", "pwp_tt", "pwp_gt"}
+_BASELINE_KEYS: dict[str, set[str]] = {
+    "exponential": {"rate"},
+    "weibull": {"shape", "scale"},
+    "gompertz": {"rate", "shape"},
+}
+
+
+def _validate_baseline_params(
+    baseline: str, baseline_params: dict[str, float] | None
+) -> None:
+    """Check the parameters supplied for a baseline hazard family.
+
+    Unknown keys are rejected rather than ignored, so a misspelt parameter
+    surfaces immediately instead of silently leaving the default in place.
+    """
+    ensure_in_choices(baseline, "baseline", _BASELINE_KEYS.keys())
+
+    if baseline_params is None:
+        return
+
+    if not isinstance(baseline_params, dict):
+        raise ParameterError(
+            "baseline_params", baseline_params, "must be a dict or None"
+        )
+
+    allowed = _BASELINE_KEYS[baseline]
+    unknown = set(baseline_params) - allowed
+    if unknown:
+        raise ParameterError(
+            "baseline_params",
+            baseline_params,
+            f"has no key(s) {sorted(unknown)} for baseline '{baseline}'; "
+            f"allowed keys are {sorted(allowed)}",
+        )
+
+    for key, value in baseline_params.items():
+        # A Gompertz shape may be negative, which is what makes the hazard
+        # decline; every other parameter must be strictly positive.
+        if baseline == "gompertz" and key == "shape":
+            if not isinstance(value, Real) or isinstance(value, bool) or value == 0:
+                raise ParameterError(
+                    f"baseline_params['{key}']",
+                    value,
+                    "must be a non-zero number; a negative value gives a "
+                    "declining hazard",
+                )
+            continue
+        ensure_positive(value, f"baseline_params['{key}']")
+
+
+def validate_gen_recurrent_events_inputs(
+    n: int,
+    process: str,
+    baseline: str,
+    baseline_params: dict[str, float] | None,
+    n_covariates: int,
+    stratum_effects: Sequence[float] | None,
+    max_events: int | None,
+    followup_time: float,
+    model_cens: str,
+    cens_par: float,
+) -> None:
+    """Validate parameters for :func:`gen_surv.recurrent.gen_recurrent_events`."""
+    ensure_positive_int(n, "n")
+    ensure_positive_int(n_covariates, "n_covariates")
+    ensure_censoring_model(model_cens)
+    ensure_positive(cens_par, "cens_par")
+    ensure_positive(followup_time, "followup_time")
+    ensure_in_choices(process, "process", _RECURRENT_PROCESSES)
+    _validate_baseline_params(baseline, baseline_params)
+
+    if stratum_effects is not None:
+        # Andersen-Gill is defined by an intensity that does not depend on the
+        # event history, so per-event effects contradict the process. Silently
+        # applying them would mislabel PWP data as AG, and silently dropping
+        # them would discard an argument the caller clearly meant.
+        if process == "ag":
+            raise ParameterError(
+                "stratum_effects",
+                stratum_effects,
+                "is not applicable to process='ag', whose intensity cannot "
+                "depend on the event number; use process='pwp_tt' or "
+                "process='pwp_gt'",
+            )
+        ensure_numeric_sequence(stratum_effects, "stratum_effects")
+        ensure_positive_sequence(stratum_effects, "stratum_effects")
+        if len(stratum_effects) == 0:
+            raise ParameterError(
+                "stratum_effects", stratum_effects, "must not be empty"
+            )
+
+    if max_events is not None:
+        ensure_positive_int(max_events, "max_events")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Illness-death, intervals (CMM): models/cmm.md
       - Illness-death, panel (THMM): models/thmm.md
       - Time-dependent covariates: models/tdcm.md
+      - Recurrent events: models/recurrent-events.md
   - Guides:
       - guides/index.md
       - Censoring: guides/censoring.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -241,6 +241,51 @@ def test_dataset_piecewise(monkeypatch):
     assert captured["betas"] == [0.4]
 
 
+def test_dataset_recurrent_events(monkeypatch):
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame({"start": [0.0], "stop": [1.0], "status": [1]})
+
+    monkeypatch.setattr("gen_surv.cli.generate", fake_generate)
+    dataset(
+        model="recurrent_events",
+        n=1,
+        process="pwp_gt",
+        baseline="weibull",
+        shape=1.2,
+        scale=2.0,
+        stratum_effects=[1.0, 2.0],
+        max_events=4,
+        followup_time=8.0,
+        beta=[0.3, -0.1],
+        output=None,
+    )
+    assert captured["process"] == "pwp_gt"
+    assert captured["baseline"] == "weibull"
+    # Only the keys the chosen baseline accepts are forwarded.
+    assert captured["baseline_params"] == {"shape": 1.2, "scale": 2.0}
+    assert captured["stratum_effects"] == [1.0, 2.0]
+    assert captured["max_events"] == 4
+    assert captured["followup_time"] == 8.0
+    assert captured["betas"] == [0.3, -0.1]
+
+
+def test_dataset_recurrent_events_exponential_baseline(monkeypatch):
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame({"start": [0.0], "stop": [1.0], "status": [1]})
+
+    monkeypatch.setattr("gen_surv.cli.generate", fake_generate)
+    dataset(
+        model="recurrent_events", n=1, baseline="exponential", rate=0.7, output=None
+    )
+    assert captured["baseline_params"] == {"rate": 0.7}
+
+
 def test_dataset_validation_error(monkeypatch, capsys):
     def bad_generate(**kwargs: Any):
         raise ValidationError("invalid n")

--- a/tests/test_recurrent.py
+++ b/tests/test_recurrent.py
@@ -1,0 +1,435 @@
+"""Tests for the recurrent event generator.
+
+These check the process the generator claims to produce, not only the shape of
+the frame: event counts against the theoretical mean of the counting process,
+rate ratios against ``exp(beta)``, gap-time distributions against the stratum
+effects, and the structural invariants of the counting-process layout.
+
+All draws use fixed seeds, so a failure is a real regression rather than Monte
+Carlo noise.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gen_surv import generate
+from gen_surv.recurrent import gen_recurrent_events
+from gen_surv.validation import ValidationError
+
+# Large enough to pin a mean count to about half a percent.
+_N = 20_000
+_SEED = 20260823
+
+# Effectively no random dropout, so follow-up ends at ``followup_time``.
+_NO_DROPOUT = 1e9
+
+_FOLLOWUP = 5.0
+
+
+def _event_counts(frame: pd.DataFrame) -> pd.Series:
+    """Number of observed events per subject."""
+    return frame.groupby("id")["status"].sum()
+
+
+# --------------------------------------------------------------------------
+# Structure of the counting-process layout
+# --------------------------------------------------------------------------
+
+
+def test_columns_and_dtypes() -> None:
+    frame = gen_recurrent_events(
+        n=20, betas=[0.1, -0.1], followup_time=_FOLLOWUP, seed=_SEED
+    )
+
+    assert list(frame.columns) == ["id", "start", "stop", "status", "enum", "X0", "X1"]
+    assert frame["id"].dtype == "int64"
+    assert frame["status"].dtype == "int64"
+    assert frame["enum"].dtype == "int64"
+
+
+def test_intervals_are_contiguous_and_ordered() -> None:
+    """Each subject's intervals must tile its follow-up without gaps."""
+    frame = gen_recurrent_events(
+        n=500,
+        baseline_params={"rate": 1.0},
+        betas=[0.1, 0.1],
+        followup_time=6.0,
+        cens_par=8.0,
+        seed=_SEED,
+    )
+
+    for _, subject in frame.sort_values(["id", "start"]).groupby("id"):
+        starts = subject["start"].to_numpy()
+        stops = subject["stop"].to_numpy()
+
+        assert starts[0] == 0.0, "follow-up must open at time zero"
+        assert (stops > starts).all(), "every interval must have positive width"
+        np.testing.assert_allclose(starts[1:], stops[:-1], err_msg="gap between rows")
+        assert list(subject["enum"]) == list(range(1, len(subject) + 1))
+
+
+def test_every_subject_appears_even_without_events() -> None:
+    """A subject with no events still contributes its censored interval."""
+    frame = gen_recurrent_events(
+        n=300,
+        baseline_params={"rate": 0.01},  # events are very unlikely
+        betas=[0.0, 0.0],
+        followup_time=1.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    assert frame["id"].nunique() == 300
+    assert (_event_counts(frame) == 0).any(), "expected some event-free subjects"
+    assert (frame.groupby("id").size() >= 1).all()
+
+
+def test_follow_up_never_exceeds_the_administrative_end() -> None:
+    frame = gen_recurrent_events(
+        n=500,
+        baseline_params={"rate": 2.0},
+        betas=[0.0, 0.0],
+        followup_time=3.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    assert frame["stop"].max() <= 3.0 + 1e-12
+    np.testing.assert_allclose(frame.groupby("id")["stop"].max().to_numpy(), 3.0)
+
+
+def test_last_row_of_each_subject_is_censored() -> None:
+    frame = gen_recurrent_events(
+        n=200,
+        baseline_params={"rate": 1.0},
+        betas=[0.0, 0.0],
+        followup_time=4.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    last = frame.sort_values(["id", "start"]).groupby("id").last()
+    assert (last["status"] == 0).all()
+
+
+# --------------------------------------------------------------------------
+# Andersen-Gill: the counting process itself
+# --------------------------------------------------------------------------
+
+
+def test_exponential_baseline_gives_a_poisson_count() -> None:
+    """With a constant intensity, N(T) is Poisson with mean ``rate * T``.
+
+    Poisson means the variance equals the mean, which distinguishes this from a
+    process that merely gets the average right.
+    """
+    rate = 0.5
+    frame = gen_recurrent_events(
+        n=_N,
+        baseline_params={"rate": rate},
+        betas=[0.0, 0.0],
+        followup_time=_FOLLOWUP,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    counts = _event_counts(frame)
+    expected = rate * _FOLLOWUP
+
+    np.testing.assert_allclose(counts.mean(), expected, rtol=0.05)
+    np.testing.assert_allclose(counts.var(ddof=1), expected, rtol=0.10)
+
+
+def test_weibull_baseline_count_matches_its_cumulative_hazard() -> None:
+    """E[N(T)] is the integrated baseline hazard, here ``(T / scale) ** shape``."""
+    shape, scale = 1.5, 2.0
+    frame = gen_recurrent_events(
+        n=_N,
+        baseline="weibull",
+        baseline_params={"shape": shape, "scale": scale},
+        betas=[0.0, 0.0],
+        followup_time=_FOLLOWUP,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    expected = (_FOLLOWUP / scale) ** shape
+    np.testing.assert_allclose(_event_counts(frame).mean(), expected, rtol=0.05)
+
+
+def test_gompertz_baseline_count_matches_its_cumulative_hazard() -> None:
+    """E[N(T)] = (rate / shape) * (exp(shape * T) - 1)."""
+    rate, shape = 0.3, 0.2
+    frame = gen_recurrent_events(
+        n=_N,
+        baseline="gompertz",
+        baseline_params={"rate": rate, "shape": shape},
+        betas=[0.0, 0.0],
+        followup_time=_FOLLOWUP,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    expected = rate / shape * (np.exp(shape * _FOLLOWUP) - 1.0)
+    np.testing.assert_allclose(_event_counts(frame).mean(), expected, rtol=0.05)
+
+
+def test_covariate_multiplies_the_intensity_by_exp_beta() -> None:
+    """A binary covariate with ``beta = log 2`` must double the event rate."""
+    frame = gen_recurrent_events(
+        n=_N,
+        baseline_params={"rate": 0.5},
+        betas=[np.log(2.0), 0.0],
+        covariate_dist="binary",
+        covariate_params={"p": 0.5},
+        followup_time=_FOLLOWUP,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    exposed = frame["X0"] > 0.5
+    rates = {
+        group: frame.loc[mask, "status"].sum()
+        / (frame.loc[mask, "stop"] - frame.loc[mask, "start"]).sum()
+        for group, mask in (("treated", exposed), ("control", ~exposed))
+    }
+
+    np.testing.assert_allclose(rates["treated"] / rates["control"], 2.0, rtol=0.05)
+
+
+# --------------------------------------------------------------------------
+# Prentice-Williams-Peterson: stratum effects and the clock
+# --------------------------------------------------------------------------
+
+
+def test_stratum_effects_scale_the_gap_times() -> None:
+    """Doubling the intensity after the first event halves the mean gap."""
+    frame = gen_recurrent_events(
+        n=_N,
+        process="pwp_gt",
+        baseline_params={"rate": 1.0},
+        betas=[0.0, 0.0],
+        stratum_effects=[1.0, 2.0],
+        followup_time=20.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    events = frame[frame["status"] == 1].assign(gap=lambda d: d["stop"] - d["start"])
+
+    np.testing.assert_allclose(
+        events.loc[events["enum"] == 1, "gap"].mean(), 1.0, rtol=0.05
+    )
+    np.testing.assert_allclose(
+        events.loc[events["enum"] > 1, "gap"].mean(), 0.5, rtol=0.05
+    )
+
+
+def test_unit_stratum_effects_reduce_pwp_to_andersen_gill() -> None:
+    """PWP in total time with no stratum effect is Andersen-Gill."""
+    common = dict(
+        n=200,
+        baseline_params={"rate": 0.7},
+        betas=[0.3, -0.1],
+        followup_time=4.0,
+        seed=_SEED,
+    )
+
+    ag = gen_recurrent_events(process="ag", **common)
+    pwp = gen_recurrent_events(process="pwp_tt", stratum_effects=[1.0], **common)
+
+    pd.testing.assert_frame_equal(ag, pwp)
+
+
+def test_exponential_baseline_makes_the_clock_irrelevant() -> None:
+    """A constant hazard is memoryless, so resetting the clock changes nothing."""
+    common = dict(
+        n=300,
+        baseline_params={"rate": 0.8},
+        betas=[0.2, -0.1],
+        followup_time=6.0,
+        seed=_SEED,
+    )
+
+    forward = gen_recurrent_events(process="ag", **common)
+    reset = gen_recurrent_events(process="pwp_gt", **common)
+
+    pd.testing.assert_frame_equal(forward, reset, atol=1e-9)
+
+
+def test_resetting_the_clock_matters_for_a_rising_hazard() -> None:
+    """With a Weibull shape above 1, the forward clock produces far more events.
+
+    On a forward clock the hazard keeps climbing with time since entry; on a
+    reset clock every event returns it to the start of the curve.
+    """
+    common = dict(
+        n=2000,
+        baseline="weibull",
+        baseline_params={"shape": 2.0, "scale": 2.0},
+        betas=[0.0, 0.0],
+        followup_time=6.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    forward = _event_counts(gen_recurrent_events(process="ag", **common)).mean()
+    reset = _event_counts(gen_recurrent_events(process="pwp_gt", **common)).mean()
+
+    assert forward > 2 * reset, (
+        f"forward clock produced {forward:.2f} events per subject against "
+        f"{reset:.2f} on a reset clock; the two clocks should differ sharply "
+        "for a rising hazard"
+    )
+
+
+def test_stratum_effects_are_rejected_by_andersen_gill() -> None:
+    """``ag`` has no event-number dependence, so per-event effects must raise.
+
+    Applying them quietly would produce PWP data under an Andersen-Gill label;
+    dropping them quietly would discard an argument the caller meant.
+    """
+    with pytest.raises(ValidationError, match="not applicable to process='ag'"):
+        gen_recurrent_events(
+            n=200,
+            process="ag",
+            baseline_params={"rate": 1.0},
+            betas=[0.0, 0.0],
+            stratum_effects=[1.0, 5.0],
+            followup_time=5.0,
+            seed=_SEED,
+        )
+
+
+# --------------------------------------------------------------------------
+# Caps, censoring and reproducibility
+# --------------------------------------------------------------------------
+
+
+def test_max_events_caps_the_process() -> None:
+    frame = gen_recurrent_events(
+        n=500,
+        baseline_params={"rate": 2.0},
+        betas=[0.0, 0.0],
+        followup_time=10.0,
+        cens_par=_NO_DROPOUT,
+        max_events=3,
+        seed=_SEED,
+    )
+
+    counts = _event_counts(frame)
+    assert counts.max() == 3
+    assert (counts == 3).mean() > 0.5, "the cap should bind for most subjects"
+
+
+def test_random_dropout_shortens_follow_up() -> None:
+    """Dropout applies on top of the administrative end."""
+    heavy = gen_recurrent_events(
+        n=2000,
+        baseline_params={"rate": 1.0},
+        betas=[0.0, 0.0],
+        followup_time=10.0,
+        model_cens="uniform",
+        cens_par=2.0,
+        seed=_SEED,
+    )
+    light = gen_recurrent_events(
+        n=2000,
+        baseline_params={"rate": 1.0},
+        betas=[0.0, 0.0],
+        followup_time=10.0,
+        model_cens="uniform",
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    assert heavy["stop"].max() <= 2.0 + 1e-12
+    assert _event_counts(heavy).mean() < _event_counts(light).mean()
+
+
+def test_equal_seeds_give_equal_frames() -> None:
+    common = dict(n=50, betas=[0.3, -0.2], followup_time=4.0)
+
+    pd.testing.assert_frame_equal(
+        gen_recurrent_events(seed=_SEED, **common),
+        gen_recurrent_events(seed=_SEED, **common),
+    )
+
+
+def test_different_seeds_give_different_frames() -> None:
+    common = dict(n=50, betas=[0.3, -0.2], followup_time=4.0)
+
+    first = gen_recurrent_events(seed=_SEED, **common)
+    second = gen_recurrent_events(seed=_SEED + 1, **common)
+
+    assert not first.equals(second)
+
+
+def test_generator_is_registered_with_the_dispatcher() -> None:
+    frame = generate(
+        model="recurrent_events",
+        n=10,
+        betas=[0.2, 0.1],
+        followup_time=3.0,
+        seed=_SEED,
+    )
+
+    assert {"id", "start", "stop", "status", "enum"}.issubset(frame.columns)
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"n": 0},
+        {"process": "cox"},
+        {"baseline": "lognormal"},
+        {"followup_time": 0.0},
+        {"cens_par": -1.0},
+        {"model_cens": "gamma"},
+        {"max_events": 0},
+        {"n_covariates": 0},
+        {"stratum_effects": []},
+        {"stratum_effects": [1.0, -2.0]},
+        {"baseline_params": {"rate": 0.0}},
+        {"baseline_params": {"lambda": 1.0}},
+        {"baseline": "gompertz", "baseline_params": {"rate": 1.0, "shape": 0.0}},
+    ],
+)
+def test_invalid_parameters_are_rejected(kwargs: dict) -> None:
+    defaults = dict(n=10, betas=[0.1, 0.1], followup_time=2.0, seed=_SEED)
+    defaults.update(kwargs)
+
+    with pytest.raises(ValidationError):
+        gen_recurrent_events(**defaults)
+
+
+def test_gompertz_accepts_a_negative_shape() -> None:
+    """A declining Gompertz hazard is legitimate, and has a finite total hazard."""
+    frame = gen_recurrent_events(
+        n=1000,
+        baseline="gompertz",
+        baseline_params={"rate": 1.0, "shape": -0.5},
+        betas=[0.0, 0.0],
+        followup_time=100.0,
+        cens_par=_NO_DROPOUT,
+        seed=_SEED,
+    )
+
+    # Total hazard converges to rate / |shape| = 2, so counts stay small even
+    # over very long follow-up.
+    assert _event_counts(frame).mean() < 4.0
+
+
+def test_betas_length_sets_the_covariate_count() -> None:
+    frame = gen_recurrent_events(
+        n=20, betas=[0.1, 0.2, -0.3], followup_time=2.0, seed=_SEED
+    )
+
+    assert {"X0", "X1", "X2"}.issubset(frame.columns)
+    assert "X3" not in frame.columns


### PR DESCRIPTION
First item of the roadmap's **Model expansion**: recurrent events, where a subject stays at risk after the event rather than leaving the study.

## Three processes

| `process` | Intensity | Clock |
|---|---|---|
| `ag` | Andersen-Gill — `h0(t) exp(Xβ)`, independent of the event history | forward from entry |
| `pwp_tt` | PWP total time — `h0(t) s_k exp(Xβ)`, scaled per event number | forward from entry |
| `pwp_gt` | PWP gap time — `h0(w) s_k exp(Xβ)` | resets after each event |

Baselines are `exponential`, `weibull` or `gompertz`, sampled by inverting the cumulative hazard. A negative Gompertz shape is accepted: a declining hazard with a finite total is a real property of that family, so events simply stop.

## Output

Counting-process intervals — the layout the roadmap records as canonical for transition data — plus an `enum` column for the event number:

```text
 id  start   stop  status  enum      X0      X1
  0 0.0000 1.5050       1     1  0.3047 -1.0400
  0 1.5050 1.6063       1     2  0.3047 -1.0400
  0 1.6063 3.1723       1     3  0.3047 -1.0400
  0 3.1723 5.0000       0     4  0.3047 -1.0400
  2 0.0000 1.3893       1     1 -1.9510 -1.3022
  2 1.3893 5.0000       0     2 -1.9510 -1.3022
```

Intervals tile each subject's follow-up and every subject contributes at least one row, so the sample size is `df["id"].nunique()`, never `len(df)`.

## A deliberate rejection

`stratum_effects` combined with `process="ag"` **raises**. Applying it would produce PWP data under an Andersen-Gill label; ignoring it would discard an argument the caller clearly meant. Both are the silent-wrong-answer failure mode this package has spent three releases removing.

## Tests check the process, not the frame

As the roadmap requires of new generators:

- **Poisson count** under a constant intensity — mean 2.484 and **variance 2.499** against a theoretical 2.5. The variance check is what separates a real Poisson process from one that merely gets the average right.
- **Mean count against the integrated baseline hazard** for all three families: exponential 2.484 vs 2.500, Weibull 3.923 vs 3.953, Gompertz 2.562 vs 2.577.
- **Rate ratio** — a binary covariate with `beta = log 2` gives 0.992 against 0.499, a ratio of 1.988.
- **Gap-time scaling** — `stratum_effects=[1.0, 2.0]` gives mean gaps of 0.982 and 0.488 against 1.0 and 0.5.
- **The clock matters only for a non-constant hazard** — a constant hazard is memoryless, so `ag` and `pwp_gt` produce the identical frame; with a rising Weibull the forward clock gives 7.18 events per subject against 2.53 on a reset clock.
- **Structural invariants** — contiguous intervals, `enum` incrementing, every subject present, follow-up never past the administrative end, last row censored.
- 13 parametrised validation cases.

A time-varying Cox fit on 4,000 subjects returns `X0` 0.399 and `X1` −0.201 against a truth of `[0.4, -0.2]`, and the `enum` coefficient comes out at −0.004 — the Andersen-Gill assumption visible in the generated data.

## Wiring

Registered in `generate()`, exported at the top level, and added to the CLI with `--process`, `--baseline`, `--rate`, `--stratum-effects`, `--max-events` and `--followup-time`. The CLI builds `baseline_params` from only the flags belonging to the chosen baseline, since the generator rejects keys that do not belong to it.

Docs: a model page covering the three processes, the baselines, the recovery check and the clock comparison, plus updates to the home page, model index, output schemas, CLI guide, API reference and README. `TODO.md` ticks the item.

## Verification

`pytest`: 294 passed, 4 skipped. `mkdocs build --strict`: clean. pre-commit: black, isort, flake8, mypy all pass.

## Note on ordering

The roadmap places **Architecture** before model expansion, and the baseline-hazard work in particular. This generator carries a small internal cumulative-hazard helper rather than a public `BaselineHazard` protocol, so it does not pre-empt that design — when the protocol lands, this module becomes one of its first callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add recurrent event generation (Andersen-Gill and PWP) returning counting-process intervals with an `enum` event counter, so subjects remain at risk after events. This enables simulating repeated events and expands the model set to twelve.

- Baselines: `exponential`, `weibull`, `gompertz` (negative Gompertz shape allowed; events can stop when the total hazard is finite).
- Validation change: `stratum_effects` with `process="ag"` now raises instead of being applied or ignored.

**API and CLI**
- `generate(model="recurrent_events")` dispatches to `gen_recurrent_events` (exported at top level).
- CLI adds `recurrent_events` with `--process` (`ag`, `pwp_tt`, `pwp_gt`), `--baseline` (`exponential`, `weibull`, `gompertz`), `--rate`, `--shape`, `--scale`, `--stratum-effects`, `--max-events`, `--followup-time`. The CLI only forwards parameters valid for the chosen baseline.
- Output schema: `["id", "start", "stop", "status", "enum", "X0", …]`; intervals tile follow-up and the last row per subject is censored unless capped by `max_events`.

**Review and migration notes**
- Tests verify: Poisson counts under constant intensity (variance equals mean), mean counts match integrated hazards for all baselines, rate ratios follow `exp(beta)`, gap-time scaling from `stratum_effects`, clock effects (forward vs reset), and structural invariants.
- Migration: update any code assuming one row per subject to count subjects with `df["id"].nunique()`; do not pass `stratum_effects` when `process="ag"`.

<sup>Written for commit fc00b030149e4a969fd07474088eac9a4d51645c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

