### PR TITLE
feat: return configuration and ground truth from simulate()

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,12 +105,18 @@ Small, concrete, and each one has already cost time:
 Structural work that makes the model expansion below tractable rather than
 repetitive.
 
-- [ ] **`SimulationConfig` and `SimulationResult`.** (next) Generators currently return a
-      DataFrame and discard everything else. Returning the configuration and the
-      ground truth alongside the data — linear predictors, baseline hazard, cure
-      status, latent cause-specific times — is what makes the package useful for
-      methodological work, where the true values are the point. The existing
-      `gen_*` functions stay as thin wrappers returning a DataFrame.
+- [x] **`SimulationConfig` and `SimulationResult`.** `simulate()` returns the
+      frame, the configuration that produced it (parameters, seed and the
+      `gen_surv` version) and a `truth` mapping: coefficients actually used —
+      including those drawn at random, which were previously unknowable —
+      covariates, linear predictors, latent event and censoring times, cure
+      status, cause-specific times, transition times, and the `tdcm` crossover
+      time the frame cannot express. All twelve generators report.
+
+      Implemented with a `ContextVar` sink rather than the tuple-returning
+      wrappers first sketched here: generators keep their signatures, gain one
+      `record()` call each, and the frozen baselines are byte-identical before
+      and after. That mattered more than the shape of the internal API.
 - [x] **Baseline hazard abstraction.** `gen_surv.baseline` defines a
       runtime-checkable `BaselineHazard` protocol -- `hazard`,
       `cumulative_hazard` and its inverse -- with frozen, self-validating

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,6 +11,7 @@ or the [model pages](../models/index.md).
 | Name | Kind | Page |
 |---|---|---|
 | `generate` | dispatcher over all twelve models | [generate](generate.md) |
+| `simulate`, `SimulationConfig`, `SimulationResult` | data with its configuration and ground truth | [Simulation results](results.md) |
 | `gen_cphm` | Cox proportional hazards | [Generators](generators.md#gen_surv.cphm) |
 | `gen_aft_log_normal`, `gen_aft_weibull`, `gen_aft_log_logistic` | AFT models | [Generators](generators.md#gen_surv.aft) |
 | `gen_piecewise_exponential` | piecewise constant hazard | [Generators](generators.md#gen_surv.piecewise) |

--- a/docs/api/results.md
+++ b/docs/api/results.md
@@ -1,0 +1,7 @@
+# Simulation results
+
+The configuration and ground truth returned alongside the data. See the
+[guide](../guides/simulation-results.md) for what the ``truth`` keys mean per
+model.
+
+::: gen_surv.results

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,6 +4,11 @@ Task-oriented pages: everything that is not "which model should I use".
 
 <div class="grid cards" markdown>
 
+-   :material-clipboard-check: **[Configuration and ground truth](simulation-results.md)**
+
+    `simulate()` returns the coefficients, latent times and cure status the
+    frame cannot show — what a simulation study is actually about.
+
 -   :material-chart-bell-curve: **[Baseline hazards](baselines.md)**
 
     The five hazard families every sampler draws from, and how to supply one of

--- a/docs/guides/simulation-results.md
+++ b/docs/guides/simulation-results.md
@@ -1,0 +1,160 @@
+# Configuration and ground truth
+
+`generate()` returns a DataFrame — what an analyst wants, and what an estimator
+consumes. It is not what a **methodologist** wants. The interesting quantities
+in a simulation study are precisely the ones a real dataset could never
+contain: the coefficients that produced it, the event time before censoring
+intervened, which subjects are cured, when a covariate crossed over.
+
+`simulate()` returns those alongside the frame.
+
+```python
+from gen_surv import simulate
+
+result = simulate("cphm", n=100, beta=0.5, covariate_range=2.0,
+                  model_cens="uniform", cens_par=1.0, seed=42)
+
+result.data              # exactly what generate() returns
+result.config            # the call that produced it
+result.truth             # what the frame cannot show
+```
+
+```text
+SimulationResult(model='cphm', rows=100, subjects=100,
+                 truth=['beta', 'censoring_time', 'covariates',
+                        'event_time', 'linear_predictor'])
+```
+
+`generate()` and the `gen_*` functions are unchanged. This is an addition.
+
+## What the truth is good for
+
+### Recovering coefficients you never chose
+
+Several generators **draw their coefficients at random** when you omit them.
+Until now there was no way to find out what they were, which quietly made those
+datasets useless for validating an estimator:
+
+```python
+result = simulate("piecewise_exponential", n=100,
+                  breakpoints=[1.0], hazard_rates=[0.5, 1.5], seed=42)
+
+result.truth["betas"]          # array([0.0006, 0.1494])
+```
+
+### Seeing what censoring hid
+
+```python
+result = simulate("cphm", n=1000, beta=0.5, covariate_range=2.0,
+                  model_cens="uniform", cens_par=1.0, seed=1)
+
+event = result.truth["event_time"]
+censoring = result.truth["censoring_time"]
+
+(event > censoring).mean()          # the true censoring rate
+event[event > censoring].mean()     # when those subjects would have failed
+```
+
+The observed `time` column is `min(event, censoring)` by construction, so these
+two arrays reconstruct it exactly — which is the check that the truth report
+describes the data it came with.
+
+### Building the analysis dataset a naive frame cannot support
+
+`tdcm` records only the value of its time-dependent covariate at exit, never
+the moment it switched. The crossover time is in the truth:
+
+```python
+result = simulate("tdcm", n=500, dist="weibull", corr=0.5,
+                  dist_par=[1.0, 2.0, 1.0, 2.0], model_cens="uniform",
+                  cens_par=5.0, beta=[0.5, 0.3], lam=1.0, seed=1)
+
+result.truth["crossover_time"]      # one per subject
+```
+
+With it you can split each subject at the crossover into the two risk intervals
+a time-varying Cox model needs.
+
+## The keys
+
+Shared vocabulary, where a model has the quantity:
+
+| Key | Meaning |
+|---|---|
+| `beta` / `betas` | the coefficients actually used |
+| `covariates` | the covariate matrix |
+| `linear_predictor` | `covariates @ betas` |
+| `event_time` | the latent event time, before censoring was applied |
+| `censoring_time` | the drawn censoring time |
+
+Model-specific:
+
+| Model | Additional keys |
+|---|---|
+| `piecewise_exponential` | `breakpoints`, `hazard_rates` |
+| `competing_risks`, `competing_risks_weibull` | `cause_times` (one column per cause), `first_event_time` |
+| `mixture_cure` | `betas_survival`, `betas_cure`, `cure_linear_predictor`, `cured` |
+| `cmm`, `thmm` | `rate`, `transition_times` (`t12`, `t13`, `t23`) |
+| `tdcm` | `crossover_time`, `switched_before_exit` |
+| `recurrent_events` | `baseline` (the object), `followup_end`, `dropout_time` |
+
+## As a frame
+
+`truth_frame()` returns the per-subject entries, ready to join onto the data:
+
+```python
+result = simulate("mixture_cure", n=500, cure_fraction=0.3, seed=1)
+result.truth_frame().head()
+```
+
+Scalars and anything not one-per-subject are left out, so the result always
+lines up with the subjects.
+
+## Configurations as values
+
+`SimulationConfig` is the specification: model, parameters, and the `gen_surv`
+version that ran it. Version matters — a bug fix in a sampler changes what a
+seed produces, so a configuration without one is not reproducible.
+
+```python
+from gen_surv import SimulationConfig
+
+base = SimulationConfig("cphm", {"n": 500, "beta": 0.5, "covariate_range": 2.0,
+                                 "model_cens": "uniform", "cens_par": 1.0})
+
+for seed in range(200):
+    result = base.replace(seed=seed).run()
+    ...
+```
+
+`replace()` returns a copy, so `base` is never mutated and a sweep reads as one
+thing varying.
+
+Configurations serialise, which is what makes a scenario shareable:
+
+```python
+import json
+
+json.dumps(base.to_dict())
+SimulationConfig.from_dict(json.loads(text))
+```
+
+## How it works
+
+Generators do not change signature and do not return tuples. Each calls an
+internal `record()` at the point where the values exist; outside a capture
+block that is a no-op, so `gen_*` behaves exactly as before. `simulate()` opens
+the block and collects what lands in it.
+
+The sink is a `ContextVar`, so concurrent simulations in threads or async tasks
+cannot see each other's truth.
+
+This design was chosen so that adding the feature could not perturb a single
+draw: the [frozen output baselines](https://github.com/DiogoRibeiro7/genSurvPy/tree/develop/tests/baselines)
+for all twelve generators are byte-identical before and after.
+
+## Related
+
+- [Reproducibility](../getting-started/reproducibility.md) — seeds, versions and what is guaranteed
+- [Choosing a model](../models/index.md)
+- API: [Simulation results](../api/results.md)

--- a/gen_surv/__init__.py
+++ b/gen_surv/__init__.py
@@ -34,6 +34,7 @@ from .interface import generate
 from .mixture import cure_fraction_estimate, gen_mixture_cure
 from .piecewise import gen_piecewise_exponential
 from .recurrent import gen_recurrent_events
+from .results import SimulationConfig, SimulationResult, simulate
 from .sklearn_adapter import GenSurvDataGenerator
 from .tdcm import gen_tdcm
 from .thmm import gen_thmm
@@ -69,6 +70,9 @@ except ImportError:
 __all__ = [
     # Main interface
     "generate",
+    "simulate",
+    "SimulationConfig",
+    "SimulationResult",
     "__version__",
     # Individual generators
     "gen_cphm",

--- a/gen_surv/_truth.py
+++ b/gen_surv/_truth.py
@@ -1,0 +1,66 @@
+"""A scoped sink for the ground truth a generator computes but does not return.
+
+Generators build quantities no real dataset could contain — the coefficients
+actually used, the latent event time before censoring intervened, which
+subjects are cured — and then discard all but the frame.
+
+Rather than changing twelve signatures or returning tuples the ordinary caller
+does not want, a generator calls :func:`record` at the point where those values
+exist. Outside a :func:`capture` block that is a no-op, so ``gen_*`` behaves
+exactly as before; inside one, the values land in the dictionary
+:func:`gen_surv.simulate` returns.
+
+The sink is a :class:`~contextvars.ContextVar`, so it is per-thread and
+per-task and cannot leak between concurrent simulations.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator
+
+_sink: ContextVar[dict[str, Any] | None] = ContextVar(
+    "gen_surv_truth_sink", default=None
+)
+
+
+def record(**values: Any) -> None:
+    """Record ground truth, if anything is capturing it.
+
+    Call this where the values exist, immediately before returning the frame.
+    Outside a :func:`capture` block it does nothing at all.
+
+    Parameters
+    ----------
+    **values
+        Named ground-truth quantities. Use the shared vocabulary where it
+        applies — ``beta``/``betas``, ``covariates``, ``linear_predictor``,
+        ``event_time``, ``censoring_time`` — so results are comparable across
+        models, and model-specific names otherwise.
+    """
+    sink = _sink.get()
+    if sink is not None:
+        sink.update(values)
+
+
+@contextmanager
+def capture() -> Iterator[dict[str, Any]]:
+    """Collect everything :func:`record` reports inside this block.
+
+    Examples
+    --------
+    >>> from gen_surv._truth import capture
+    >>> from gen_surv import gen_cphm
+    >>> with capture() as truth:
+    ...     frame = gen_cphm(n=10, model_cens="uniform", cens_par=1.0,
+    ...                      beta=0.5, covariate_range=2.0, seed=1)
+    >>> sorted(truth)
+    ['beta', 'censoring_time', 'covariates', 'event_time', 'linear_predictor']
+    """
+    sink: dict[str, Any] = {}
+    token = _sink.set(sink)
+    try:
+        yield sink
+    finally:
+        _sink.reset(token)

--- a/gen_surv/aft.py
+++ b/gen_surv/aft.py
@@ -7,6 +7,7 @@ from typing import List, Literal
 import numpy as np
 import pandas as pd
 
+from ._truth import record
 from .censoring import rexpocens, runifcens
 from .validation import (
     validate_gen_aft_log_logistic_inputs,
@@ -73,6 +74,14 @@ def gen_aft_log_normal(
 
     observed_time = np.minimum(T, C)
     status = (T <= C).astype(int)
+
+    record(
+        betas=np.asarray(beta, dtype=float),
+        covariates=X,
+        linear_predictor=X @ np.asarray(beta, dtype=float),
+        event_time=T,
+        censoring_time=C,
+    )
 
     data = pd.DataFrame({"id": np.arange(n), "time": observed_time, "status": status})
 
@@ -153,6 +162,14 @@ def gen_aft_weibull(
     # Observed time is the minimum of event time and censoring time
     observed_time = np.minimum(T, C)
     status = (T <= C).astype(int)
+
+    record(
+        betas=np.asarray(beta, dtype=float),
+        covariates=X,
+        linear_predictor=X @ np.asarray(beta, dtype=float),
+        event_time=T,
+        censoring_time=C,
+    )
 
     data = pd.DataFrame({"id": np.arange(n), "time": observed_time, "status": status})
 
@@ -244,6 +261,14 @@ def gen_aft_log_logistic(
     # Observed time is the minimum of event time and censoring time
     observed_time = np.minimum(T, C)
     status = (T <= C).astype(int)
+
+    record(
+        betas=np.asarray(beta, dtype=float),
+        covariates=X,
+        linear_predictor=X @ np.asarray(beta, dtype=float),
+        event_time=T,
+        censoring_time=C,
+    )
 
     data = pd.DataFrame({"id": np.arange(n), "time": observed_time, "status": status})
 

--- a/gen_surv/cmm.py
+++ b/gen_surv/cmm.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from gen_surv._rng import RandomStateLike, resolve_rng
+from gen_surv._truth import record
 from gen_surv.censoring import CensoringFunc, rexpocens, runifcens
 from gen_surv.validation import validate_gen_cmm_inputs
 
@@ -189,6 +190,14 @@ def gen_cmm(
             "status": (~censored_in_2).astype(int),
             "X0": z1[reached_2],
         }
+    )
+
+    record(
+        beta=np.asarray(beta, dtype=float),
+        rate=np.asarray(rate, dtype=float),
+        covariates=z1,
+        censoring_time=c,
+        transition_times={"t12": t12, "t13": t13, "t23": t23},
     )
 
     data = pd.concat([to_2, to_3, from_2], ignore_index=True)

--- a/gen_surv/competing_risks.py
+++ b/gen_surv/competing_risks.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from ._covariates import generate_covariates, prepare_betas_matrix, set_covariate_params
+from ._truth import record
 from .censoring import rexpocens, runifcens
 from .validation import (
     ParameterError,
@@ -155,6 +156,14 @@ def gen_competing_risks(
         over_max = observed_times > max_time
         observed_times[over_max] = max_time
         status[over_max] = 0  # Censored if beyond max_time
+
+    record(
+        betas=betas,
+        covariates=X,
+        cause_times=event_times,
+        censoring_time=cens_times,
+        first_event_time=min_event_times,
+    )
 
     # Create DataFrame
     data = pd.DataFrame({"id": np.arange(n), "time": observed_times, "status": status})
@@ -311,6 +320,14 @@ def gen_competing_risks_weibull(
         over_max = observed_times > max_time
         observed_times[over_max] = max_time
         status[over_max] = 0  # Censored if beyond max_time
+
+    record(
+        betas=betas,
+        covariates=X,
+        cause_times=event_times,
+        censoring_time=cens_times,
+        first_event_time=min_event_times,
+    )
 
     # Create DataFrame
     data = pd.DataFrame({"id": np.arange(n), "time": observed_times, "status": status})

--- a/gen_surv/cphm.py
+++ b/gen_surv/cphm.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 
+from gen_surv._truth import record
 from gen_surv.censoring import CensoringFunc, rexpocens, runifcens
 from gen_surv.validation import validate_gen_cphm_inputs
 
@@ -49,6 +50,10 @@ def generate_cphm_data(
     rng = np.random.default_rng(seed)
 
     data: NDArray[np.float64] = np.zeros((n, 3), dtype=float)
+    # Kept so the latent times can be reported as ground truth; they do not
+    # affect any draw.
+    event_times: NDArray[np.float64] = np.zeros(n, dtype=float)
+    censoring_times: NDArray[np.float64] = np.zeros(n, dtype=float)
 
     for k in range(n):
         z = rng.uniform(0, covariate_range)
@@ -59,7 +64,16 @@ def generate_cphm_data(
         status = int(x <= c)
 
         data[k, :] = [time, status, z]
+        event_times[k] = x
+        censoring_times[k] = c
 
+    record(
+        beta=beta,
+        covariates=data[:, 2].copy(),
+        linear_predictor=beta * data[:, 2],
+        event_time=event_times,
+        censoring_time=censoring_times,
+    )
     return data
 
 

--- a/gen_surv/mixture.py
+++ b/gen_surv/mixture.py
@@ -16,6 +16,7 @@ _TAIL_FRACTION: float = 0.1
 _SMOOTH_MIN_TAIL: int = 3
 
 from ._covariates import generate_covariates, prepare_betas, set_covariate_params
+from ._truth import record
 from .censoring import rexpocens, runifcens
 from .validation import ParameterError, ensure_positive, validate_gen_mixture_inputs
 
@@ -168,6 +169,16 @@ def gen_mixture_cure(
     survival_times = _survival_times(cured, lp_survival, baseline_hazard, max_time, rng)
     observed_times, status = _apply_censoring(
         survival_times, model_cens, cens_par, max_time, rng
+    )
+
+    record(
+        betas_survival=betas_survival_arr,
+        betas_cure=betas_cure_arr,
+        covariates=X,
+        linear_predictor=lp_survival,
+        cure_linear_predictor=lp_cure,
+        cured=cured,
+        event_time=survival_times,
     )
 
     data = pd.DataFrame(

--- a/gen_surv/piecewise.py
+++ b/gen_surv/piecewise.py
@@ -12,6 +12,7 @@ import pandas as pd
 from numpy.typing import NDArray
 
 from ._covariates import generate_covariates, prepare_betas, set_covariate_params
+from ._truth import record
 from .censoring import rexpocens, runifcens
 from .validation import validate_gen_piecewise_inputs, validate_piecewise_params
 
@@ -166,6 +167,16 @@ def gen_piecewise_exponential(
     # Determine observed time and status
     observed_times = np.minimum(survival_times, cens_times)
     status = (survival_times <= cens_times).astype(int)
+
+    record(
+        betas=betas,
+        covariates=X,
+        linear_predictor=linear_predictor,
+        event_time=survival_times,
+        censoring_time=cens_times,
+        breakpoints=np.asarray(breakpoints, dtype=float),
+        hazard_rates=np.asarray(hazard_rates, dtype=float),
+    )
 
     # Create DataFrame
     data = pd.DataFrame({"id": np.arange(n), "time": observed_times, "status": status})

--- a/gen_surv/recurrent.py
+++ b/gen_surv/recurrent.py
@@ -30,6 +30,7 @@ from numpy.typing import NDArray
 
 from ._covariates import generate_covariates, prepare_betas, set_covariate_params
 from ._rng import RandomStateLike, resolve_rng
+from ._truth import record
 from .baseline import (
     BaselineHazard,
     ExponentialBaseline,
@@ -278,6 +279,15 @@ def gen_recurrent_events(
                 rng=rng,
             )
         )
+
+    record(
+        betas=coefficients,
+        covariates=covariates,
+        linear_predictor=eta,
+        baseline=resolved_baseline,
+        followup_end=ends,
+        dropout_time=dropout,
+    )
 
     data = pd.DataFrame(records, columns=_COLUMNS)
     data = data.astype(

--- a/gen_surv/results.py
+++ b/gen_surv/results.py
@@ -1,0 +1,220 @@
+"""Configuration and ground truth alongside the simulated data.
+
+A generator returns a ``DataFrame``, which is what an analyst wants and what an
+estimator consumes. It is not what a *methodologist* wants: the interesting
+quantities in a simulation study are the ones a real dataset could never
+contain — the coefficients that produced it, the latent event time before
+censoring intervened, which subjects are cured, when a covariate crossed over.
+
+:func:`simulate` returns those alongside the frame:
+
+>>> from gen_surv import simulate
+>>> result = simulate("cphm", n=100, beta=0.5, covariate_range=2.0,
+...                   model_cens="uniform", cens_par=1.0, seed=42)
+>>> result.data.shape
+(100, 3)
+>>> sorted(result.truth)
+['beta', 'censoring_time', 'covariates', 'event_time', 'linear_predictor']
+
+The existing ``gen_*`` functions are unchanged and still return a frame. This
+is an addition, not a replacement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, cast
+
+import numpy as np
+import pandas as pd
+
+from .validation import ParameterError
+
+__all__ = [
+    "SimulationConfig",
+    "SimulationResult",
+    "simulate",
+]
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    """Everything needed to reproduce a simulated dataset.
+
+    Attributes
+    ----------
+    model : str
+        The generator's registered name, as passed to :func:`gen_surv.generate`.
+    params : Mapping[str, Any]
+        The keyword arguments it was called with, seed included.
+    version : str
+        The ``gen_surv`` version that produced the data. A bug fix in a sampler
+        changes what a seed produces, so the version is part of the
+        specification and not decoration.
+    """
+
+    model: str
+    params: Mapping[str, Any] = field(default_factory=dict)
+    version: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model, str) or not self.model:
+            raise ParameterError("model", self.model, "must be a non-empty string")
+        object.__setattr__(self, "params", dict(self.params))
+        if not self.version:
+            from . import __version__
+
+            object.__setattr__(self, "version", __version__)
+
+    @property
+    def seed(self) -> Any:
+        """The seed the data was produced with, or ``None`` if unseeded."""
+        return self.params.get("seed")
+
+    def replace(self, **changes: Any) -> "SimulationConfig":
+        """Return a copy with ``changes`` applied to the parameters.
+
+        The natural way to sweep: hold a scenario fixed and vary one thing.
+
+        >>> base = SimulationConfig("cphm", {"n": 100, "beta": 0.5})
+        >>> base.replace(seed=7).params["seed"]
+        7
+        >>> base.params.get("seed") is None      # the original is untouched
+        True
+        """
+        return SimulationConfig(
+            model=self.model, params={**self.params, **changes}, version=self.version
+        )
+
+    def run(self) -> "SimulationResult":
+        """Run this configuration and return the result."""
+        return simulate(self.model, **self.params)
+
+    def to_dict(self) -> dict[str, Any]:
+        """A plain dictionary, for writing to JSON or YAML."""
+        return {
+            "model": self.model,
+            "params": dict(self.params),
+            "version": self.version,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SimulationConfig":
+        """Rebuild a configuration from :meth:`to_dict` output."""
+        return cls(
+            model=payload["model"],
+            params=payload.get("params", {}),
+            version=payload.get("version", ""),
+        )
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """Simulated data, the configuration behind it, and the ground truth.
+
+    Attributes
+    ----------
+    data : pandas.DataFrame
+        Exactly what the corresponding ``gen_*`` function returns.
+    config : SimulationConfig
+        The call that produced it.
+    truth : Mapping[str, Any]
+        Quantities a real dataset could not contain. Which keys are present
+        depends on the model; see :func:`simulate`.
+    """
+
+    data: pd.DataFrame
+    config: SimulationConfig
+    truth: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "truth", dict(self.truth))
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    @property
+    def n_subjects(self) -> int:
+        """Number of subjects, which is not ``len(data)`` for every model."""
+        if "id" in self.data.columns:
+            return int(self.data["id"].nunique())
+        return len(self.data)
+
+    def truth_frame(self) -> pd.DataFrame:
+        """The per-subject entries of ``truth`` as a frame.
+
+        Scalars and anything not one-per-subject are left out, so the result
+        lines up with the subjects and can be joined onto the data.
+        """
+        n = self.n_subjects
+        columns = {
+            key: np.asarray(value)
+            for key, value in self.truth.items()
+            if isinstance(value, np.ndarray) and value.ndim == 1 and len(value) == n
+        }
+        return pd.DataFrame(columns)
+
+    def __repr__(self) -> str:  # pragma: no cover - presentation only
+        return (
+            f"SimulationResult(model={self.config.model!r}, "
+            f"rows={len(self.data)}, subjects={self.n_subjects}, "
+            f"truth={sorted(self.truth)})"
+        )
+
+
+def simulate(model: str, **kwargs: Any) -> SimulationResult:
+    """Generate data and return it with its configuration and ground truth.
+
+    Parameters
+    ----------
+    model : str
+        Any name accepted by :func:`gen_surv.generate`.
+    **kwargs
+        The model's parameters, exactly as for :func:`gen_surv.generate`.
+
+    Returns
+    -------
+    SimulationResult
+        The frame, the configuration, and whatever ground truth the model can
+        expose.
+
+    Notes
+    -----
+    The keys in ``truth`` vary by model. Common ones:
+
+    ``beta`` / ``betas``
+        The coefficients actually used. This matters most where they were
+        **drawn at random** because the caller omitted them, in which case
+        there is otherwise no way to learn what they were.
+    ``covariates``
+        The covariate matrix, as an array.
+    ``linear_predictor``
+        ``covariates @ betas``.
+    ``event_time`` and ``censoring_time``
+        The latent times before the minimum of the two was taken, so you can
+        see what censoring hid.
+
+    Model-specific keys are documented on each model's page. A generator that
+    cannot expose anything beyond its frame returns an empty ``truth`` rather
+    than inventing entries.
+
+    Examples
+    --------
+    >>> from gen_surv import simulate
+    >>> result = simulate("piecewise_exponential", n=50, breakpoints=[1.0],
+    ...                   hazard_rates=[0.5, 1.5], seed=7)
+    >>> result.truth["betas"]        # drawn at random, and otherwise unknowable
+    array([...])
+    """
+    from ._truth import capture
+    from .interface import ModelType, generate
+
+    config = SimulationConfig(model=model, params=dict(kwargs))
+
+    # `generate` validates the name against the registry and raises a
+    # ChoiceError listing the valid ones, so the cast only tells the type
+    # checker what that check already guarantees at runtime.
+    with capture() as truth:
+        data = generate(cast(ModelType, model), **kwargs)
+
+    return SimulationResult(data=data, config=config, truth=truth)

--- a/gen_surv/tdcm.py
+++ b/gen_surv/tdcm.py
@@ -5,6 +5,7 @@ import pandas as pd
 from numpy.typing import NDArray
 
 from gen_surv._rng import RandomStateLike, resolve_rng
+from gen_surv._truth import record
 from gen_surv.bivariate import sample_bivariate_distribution
 from gen_surv.censoring import CensoringFunc, rexpocens, runifcens
 from gen_surv.validation import validate_gen_tdcm_inputs
@@ -66,6 +67,18 @@ def generate_censored_observations(
 
     time = np.minimum(t, c)
     status = (t <= c).astype(float)
+
+    # The crossover time is what the returned frame cannot express: it records
+    # only the covariate's value at exit, so a caller cannot split the risk
+    # interval without this.
+    record(
+        beta=np.asarray(beta, dtype=float),
+        covariates=z1,
+        crossover_time=b[:, 0],
+        event_time=t,
+        censoring_time=c,
+        switched_before_exit=z2,
+    )
 
     ids = np.arange(1, n + 1, dtype=float)
     zeros = np.zeros(n, dtype=float)

--- a/gen_surv/thmm.py
+++ b/gen_surv/thmm.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from gen_surv._rng import RandomStateLike, resolve_rng
+from gen_surv._truth import record
 from gen_surv.censoring import CensoringFunc, rexpocens, runifcens
 from gen_surv.validation import validate_gen_thmm_inputs
 
@@ -117,11 +118,18 @@ def gen_thmm(
     rfunc: CensoringFunc = runifcens if model_cens == "uniform" else rexpocens
     rng = resolve_rng(seed)
     records = []
+    # Collected for the ground-truth report; they do not affect any draw.
+    latent = {key: np.empty(n, dtype=float) for key in ("t12", "t13", "t23", "c")}
+    covariates = np.empty(n, dtype=float)
 
     for k in range(n):
         z1 = rng.uniform(0, covariate_range)
         trans = calculate_transitions(z1, cens_par, beta, rate, rfunc, rng)
         t12, t13, t23, c = trans["t12"], trans["t13"], trans["t23"], trans["c"]
+
+        covariates[k] = z1
+        for key, value in (("t12", t12), ("t13", t13), ("t23", t23), ("c", c)):
+            latent[key][k] = value
 
         # Every trajectory is observed in state 1 at entry.
         records.append([k + 1, 0.0, 1, z1])
@@ -142,5 +150,13 @@ def gen_thmm(
                 records.append([k + 1, c, 2, z1])
             else:
                 records.append([k + 1, t12 + t23, 3, z1])
+
+    record(
+        beta=np.asarray(beta, dtype=float),
+        rate=np.asarray(rate, dtype=float),
+        covariates=covariates,
+        censoring_time=latent["c"],
+        transition_times={key: latent[key] for key in ("t12", "t13", "t23")},
+    )
 
     return pd.DataFrame(records, columns=["id", "time", "state", "X0"])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - Recurrent events: models/recurrent-events.md
   - Guides:
       - guides/index.md
+      - Configuration and ground truth: guides/simulation-results.md
       - Baseline hazards: guides/baselines.md
       - Censoring: guides/censoring.md
       - Covariates: guides/covariates.md
@@ -149,6 +150,7 @@ nav:
   - API:
       - api/index.md
       - generate: api/generate.md
+      - Simulation results: api/results.md
       - Generators: api/generators.md
       - Baseline hazards: api/baselines.md
       - Censoring: api/censoring.md

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,452 @@
+"""Tests for SimulationConfig, SimulationResult and simulate().
+
+The interesting assertions are not that ``truth`` has keys, but that what it
+reports is *true*: the latent times must reconstruct the observed ones, the
+linear predictor must equal ``covariates @ betas``, and the recorded cure
+status must match the column in the frame. A truth report that drifts from the
+data it describes is worse than no truth report.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import gen_surv
+from gen_surv import SimulationConfig, SimulationResult, generate, simulate
+from gen_surv.validation import ValidationError
+
+_SEED = 20260824
+
+
+# --------------------------------------------------------------------------
+# SimulationConfig
+# --------------------------------------------------------------------------
+
+
+def test_config_records_the_version_it_ran_under() -> None:
+    config = SimulationConfig("cphm", {"n": 10, "seed": 1})
+
+    assert config.version == gen_surv.__version__
+    assert config.seed == 1
+
+
+def test_config_seed_is_none_when_unseeded() -> None:
+    assert SimulationConfig("cphm", {"n": 10}).seed is None
+
+
+def test_config_replace_varies_one_thing() -> None:
+    base = SimulationConfig("cphm", {"n": 100, "beta": 0.5})
+    sweep = [base.replace(seed=s) for s in range(3)]
+
+    assert [c.params["seed"] for c in sweep] == [0, 1, 2]
+    assert all(c.params["n"] == 100 for c in sweep), "the rest must be carried over"
+    assert "seed" not in base.params, "the original must not be mutated"
+
+
+def test_config_round_trips_through_a_dict() -> None:
+    config = SimulationConfig("cphm", {"n": 10, "beta": 0.5, "seed": 3})
+    restored = SimulationConfig.from_dict(config.to_dict())
+
+    assert restored == config
+
+
+def test_config_run_reproduces_the_same_data() -> None:
+    config = SimulationConfig(
+        "cphm",
+        {
+            "n": 50,
+            "beta": 0.5,
+            "covariate_range": 2.0,
+            "model_cens": "uniform",
+            "cens_par": 1.0,
+            "seed": _SEED,
+        },
+    )
+
+    pd.testing.assert_frame_equal(config.run().data, config.run().data)
+
+
+def test_config_rejects_an_empty_model() -> None:
+    with pytest.raises(ValidationError):
+        SimulationConfig("", {})
+
+
+def test_config_is_frozen() -> None:
+    config = SimulationConfig("cphm", {"n": 10})
+    with pytest.raises(Exception):
+        config.model = "aft_ln"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------
+# SimulationResult
+# --------------------------------------------------------------------------
+
+
+def test_result_data_matches_the_plain_generator() -> None:
+    """simulate() must not change what the generator produces."""
+    kwargs = dict(
+        n=100,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    )
+
+    pd.testing.assert_frame_equal(
+        simulate("cphm", **kwargs).data, generate(model="cphm", **kwargs)
+    )
+
+
+def test_simulate_returns_a_simulation_result() -> None:
+    result = simulate(
+        "cphm",
+        n=10,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    )
+
+    assert isinstance(result, SimulationResult)
+    assert isinstance(result.config, SimulationConfig)
+    assert isinstance(result.data, pd.DataFrame)
+
+
+def test_result_counts_subjects_not_rows() -> None:
+    result = simulate(
+        "recurrent_events",
+        n=50,
+        baseline_params={"rate": 1.0},
+        betas=[0.0, 0.0],
+        followup_time=5.0,
+        cens_par=1e9,
+        seed=_SEED,
+    )
+
+    assert result.n_subjects == 50
+    assert len(result) > 50, "a recurrent frame has more rows than subjects"
+
+
+def test_truth_frame_keeps_only_per_subject_entries() -> None:
+    result = simulate(
+        "cphm",
+        n=40,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    )
+    frame = result.truth_frame()
+
+    assert len(frame) == 40
+    assert {"event_time", "censoring_time", "covariates"}.issubset(frame.columns)
+    assert "beta" not in frame.columns, "a scalar is not a per-subject column"
+
+
+def test_capturing_truth_does_not_leak_between_calls() -> None:
+    first = simulate(
+        "cphm",
+        n=10,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    )
+    second = simulate(
+        "thmm",
+        n=10,
+        model_cens="uniform",
+        cens_par=1.0,
+        beta=[0.1, 0.2, 0.3],
+        covariate_range=1.0,
+        rate=[0.2, 0.3, 0.4],
+        seed=_SEED,
+    )
+
+    assert "event_time" in first.truth
+    assert "event_time" not in second.truth, "keys from an earlier call leaked"
+    assert "transition_times" in second.truth
+
+
+def test_plain_generator_calls_record_nothing() -> None:
+    """Outside a capture block, recording must be inert."""
+    from gen_surv._truth import _sink
+
+    generate(
+        model="cphm",
+        n=10,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    )
+
+    assert _sink.get() is None
+
+
+# --------------------------------------------------------------------------
+# Every model reports something, and what it reports is true
+# --------------------------------------------------------------------------
+
+
+CASES = {
+    "cphm": dict(
+        n=300,
+        beta=0.5,
+        covariate_range=2.0,
+        model_cens="uniform",
+        cens_par=1.0,
+        seed=_SEED,
+    ),
+    "aft_ln": dict(
+        n=300,
+        beta=[0.5, -0.3],
+        sigma=1.0,
+        model_cens="uniform",
+        cens_par=2.0,
+        seed=_SEED,
+    ),
+    "aft_weibull": dict(
+        n=300,
+        beta=[0.5, -0.3],
+        shape=1.4,
+        scale=1.1,
+        model_cens="uniform",
+        cens_par=2.0,
+        seed=_SEED,
+    ),
+    "aft_log_logistic": dict(
+        n=300,
+        beta=[0.5, -0.3],
+        shape=1.3,
+        scale=1.7,
+        model_cens="uniform",
+        cens_par=2.0,
+        seed=_SEED,
+    ),
+    "piecewise_exponential": dict(
+        n=300, breakpoints=[1.0], hazard_rates=[0.5, 1.5], seed=_SEED
+    ),
+    "competing_risks": dict(
+        n=300,
+        n_risks=2,
+        baseline_hazards=[0.4, 0.2],
+        betas=[[0.8, 0.0], [0.0, -0.5]],
+        max_time=10.0,
+        seed=_SEED,
+    ),
+    "competing_risks_weibull": dict(
+        n=300,
+        n_risks=2,
+        shape_params=[1.2, 0.8],
+        scale_params=[2.0, 1.5],
+        max_time=10.0,
+        seed=_SEED,
+    ),
+    "mixture_cure": dict(
+        n=300,
+        cure_fraction=0.3,
+        baseline_hazard=0.8,
+        betas_survival=[0.5, -0.2],
+        betas_cure=[0.3, 0.1],
+        seed=_SEED,
+    ),
+    "cmm": dict(
+        n=200,
+        model_cens="exponential",
+        cens_par=2.0,
+        beta=[0.1, 0.2, 0.3],
+        covariate_range=1.0,
+        rate=[0.1, 1.0, 0.2, 1.0, 0.1, 1.0],
+        seed=_SEED,
+    ),
+    "thmm": dict(
+        n=200,
+        model_cens="exponential",
+        cens_par=2.0,
+        beta=[0.1, 0.2, 0.3],
+        covariate_range=1.0,
+        rate=[0.2, 0.3, 0.4],
+        seed=_SEED,
+    ),
+    "tdcm": dict(
+        n=200,
+        dist="weibull",
+        corr=0.5,
+        dist_par=[1.0, 2.0, 1.0, 2.0],
+        model_cens="uniform",
+        cens_par=5.0,
+        beta=[0.5, 0.3],
+        lam=1.0,
+        seed=_SEED,
+    ),
+    "recurrent_events": dict(
+        n=200,
+        baseline_params={"rate": 0.5},
+        betas=[0.4, -0.2],
+        followup_time=5.0,
+        cens_par=8.0,
+        seed=_SEED,
+    ),
+}
+
+
+def test_every_registered_model_reports_truth() -> None:
+    from gen_surv.interface import _model_map
+
+    assert set(CASES) == set(_model_map), "a model was added without a truth case"
+
+    for model, kwargs in CASES.items():
+        result = simulate(model, **kwargs)
+        assert result.truth, f"{model} reported no ground truth at all"
+        assert result.config.model == model
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["cphm", "aft_ln", "aft_weibull", "aft_log_logistic", "piecewise_exponential"],
+)
+def test_latent_times_reconstruct_the_observed_ones(model: str) -> None:
+    """``time`` is ``min(event, censoring)``, and ``status`` says which won."""
+    result = simulate(model, **CASES[model])
+    event = np.asarray(result.truth["event_time"])
+    censoring = np.asarray(result.truth["censoring_time"])
+
+    np.testing.assert_allclose(
+        result.data["time"].to_numpy(), np.minimum(event, censoring)
+    )
+    np.testing.assert_array_equal(
+        result.data["status"].to_numpy().astype(int), (event <= censoring).astype(int)
+    )
+
+
+@pytest.mark.parametrize(
+    "model", ["aft_ln", "aft_weibull", "aft_log_logistic", "piecewise_exponential"]
+)
+def test_linear_predictor_is_covariates_times_betas(model: str) -> None:
+    result = simulate(model, **CASES[model])
+
+    np.testing.assert_allclose(
+        np.asarray(result.truth["linear_predictor"]),
+        np.asarray(result.truth["covariates"]) @ np.asarray(result.truth["betas"]),
+    )
+
+
+def test_cphm_linear_predictor_uses_its_scalar_beta() -> None:
+    result = simulate("cphm", **CASES["cphm"])
+
+    np.testing.assert_allclose(
+        np.asarray(result.truth["linear_predictor"]),
+        0.5 * result.data["X0"].to_numpy(),
+    )
+
+
+def test_randomly_drawn_betas_are_reported() -> None:
+    """Without this there is no way to learn what coefficients were used.
+
+    Several generators draw ``betas`` when the caller omits them, which
+    otherwise makes the dataset useless for validating an estimator.
+    """
+    result = simulate(
+        "piecewise_exponential",
+        n=100,
+        breakpoints=[1.0],
+        hazard_rates=[0.5, 1.5],
+        seed=_SEED,
+    )
+
+    betas = np.asarray(result.truth["betas"])
+    assert betas.shape == (2,)
+    np.testing.assert_allclose(
+        np.asarray(result.truth["linear_predictor"]),
+        np.asarray(result.truth["covariates"]) @ betas,
+    )
+
+
+@pytest.mark.parametrize("model", ["competing_risks", "competing_risks_weibull"])
+def test_competing_risks_cause_times_explain_the_status(model: str) -> None:
+    result = simulate(model, **CASES[model])
+    cause_times = np.asarray(result.truth["cause_times"])
+    status = result.data["status"].to_numpy()
+
+    np.testing.assert_allclose(
+        np.asarray(result.truth["first_event_time"]), cause_times.min(axis=1)
+    )
+    observed = status > 0
+    np.testing.assert_array_equal(
+        status[observed], (cause_times.argmin(axis=1) + 1)[observed]
+    )
+
+
+def test_mixture_cure_truth_matches_its_column() -> None:
+    result = simulate("mixture_cure", **CASES["mixture_cure"])
+
+    np.testing.assert_array_equal(
+        np.asarray(result.truth["cured"]), result.data["cured"].to_numpy()
+    )
+    np.testing.assert_allclose(
+        np.asarray(result.truth["cure_linear_predictor"]),
+        np.asarray(result.truth["covariates"]) @ np.asarray(result.truth["betas_cure"]),
+    )
+
+
+@pytest.mark.parametrize("model", ["cmm", "thmm"])
+def test_multistate_latent_times_explain_the_exit_from_state_one(model: str) -> None:
+    result = simulate(model, **CASES[model])
+    times = result.truth["transition_times"]
+    censoring = np.asarray(result.truth["censoring_time"])
+
+    expected = np.minimum(np.minimum(times["t12"], times["t13"]), censoring)
+
+    if model == "thmm":
+        observed = (
+            result.data.sort_values(["id", "time"])
+            .groupby("id")
+            .nth(1)["time"]
+            .to_numpy()
+        )
+    else:
+        rows = result.data[
+            (result.data["from_state"] == 1) & (result.data["to_state"] == 2)
+        ].sort_values("id")
+        observed = rows["stop"].to_numpy()
+
+    np.testing.assert_allclose(observed, expected)
+
+
+def test_tdcm_reports_the_crossover_time_the_frame_cannot() -> None:
+    """The frame records only the covariate's value at exit, not when it switched."""
+    result = simulate("tdcm", **CASES["tdcm"])
+
+    crossover = np.asarray(result.truth["crossover_time"])
+    assert crossover.shape == (200,)
+    assert np.all(crossover > 0)
+    np.testing.assert_allclose(
+        np.asarray(result.truth["covariates"]), result.data["covariate"].to_numpy()
+    )
+
+
+def test_recurrent_followup_end_is_the_earlier_of_dropout_and_administrative_end() -> (
+    None
+):
+    result = simulate("recurrent_events", **CASES["recurrent_events"])
+
+    np.testing.assert_allclose(
+        np.asarray(result.truth["followup_end"]),
+        np.minimum(np.asarray(result.truth["dropout_time"]), 5.0),
+    )
+
+
+def test_recurrent_reports_the_baseline_object() -> None:
+    from gen_surv.baseline import BaselineHazard
+
+    result = simulate("recurrent_events", **CASES["recurrent_events"])
+
+    assert isinstance(result.truth["baseline"], BaselineHazard)


### PR DESCRIPTION
The next architecture item: generators return a DataFrame and discard everything else, so the quantities a simulation study is actually about are lost.

`simulate()` returns them alongside the frame:

```python
result = simulate("cphm", n=100, beta=0.5, covariate_range=2.0,
                  model_cens="uniform", cens_par=1.0, seed=42)

result.data       # exactly what generate() returns
result.config     # model, parameters, seed, gen_surv version
result.truth      # beta, covariates, linear_predictor, event_time, censoring_time
```

**All twelve generators report.** The single most useful entry: several generators **draw their coefficients at random** when the caller omits them, and until now there was no way to learn what they were — which quietly made those datasets useless for validating an estimator.

```python
result = simulate("piecewise_exponential", n=100, breakpoints=[1.0],
                  hazard_rates=[0.5, 1.5], seed=42)
result.truth["betas"]          # array([0.0006, 0.1494])
```

`tdcm` gains its **crossover time**, which the frame cannot express — the limitation the model page documents.

## Implementation, and why it is not what the roadmap sketched

The roadmap proposed internal functions returning `(frame, truth)` with `gen_*` as thin wrappers. That means rewriting twelve function bodies, and the one property that mattered here was **not perturbing a single draw**.

Instead, generators keep their signatures and gain one `record()` call where the values already exist. Outside a capture block it is a no-op, so `gen_*` behaves exactly as before; `simulate()` opens the block. The sink is a `ContextVar`, so concurrent simulations cannot see each other's truth.

**The frozen baselines for all twelve generators are byte-identical before and after.** The roadmap entry records the deviation and the reason.

## The tests assert the truth is *true*

Not that the keys exist — that what they report matches the data they came with:

- `time == min(event_time, censoring_time)` and `status == (event <= censoring)`, for every one-row-per-subject model.
- `linear_predictor == covariates @ betas`.
- `cause_times.argmin(axis=1) + 1 == status` where an event was observed.
- Recorded `cured` equals the frame's column.
- `cmm`/`thmm`: the exit from state 1 equals `min(t12, t13, censoring)`.
- No leakage between calls, and `record()` inert outside a capture.

## Verification

414 passed, 0 skipped. `mkdocs build --strict` clean. black, isort, flake8, mypy pass.

---

## Separately: this work uncovered a bug in `gen_tdcm`

Writing the check "the crossover time must be consistent with `tdcov`" failed, and the cause is a **sign error** in the post-crossover event-time inversion at [tdcm.py:63](https://github.com/DiogoRibeiro7/genSurvPy/blob/develop/gen_surv/tdcm.py#L63):

```python
t2 = (log_term + x * (1 - np.exp(beta[1]))) / (lam * np.exp(beta[0] * z1 + beta[1]))
```

Correct inversion, with `τ = x/A` the crossover and `A = lam·exp(β₀z₁)`:

```
t = τ + (L − x) / (A·exp(β₁))
```

which expands to `(L + x·(exp(β₁) − 1)) / (A·exp(β₁))` — the same expression with the sign of that term flipped. Verified to machine precision against the correct form.

The consequence is not subtle. Times drawn on the "event after crossover" branch land *before* the crossover, and can go **negative**:

| `beta[1]` | subjects with a negative survival time (n=50,000) | worst |
|---|---|---|
| 0.3 | 0 | — |
| 1.0 | **6,886** | −0.53 |
| 2.0 | **14,873** | −1.64 |

This is very likely also the real explanation for the reversed `tdcov` coefficient documented on the model page, which I had attributed to time-dependent-covariate bias.

I have **not** fixed it here — it changes `tdcm`'s seeded output, so it needs its own PR with a regenerated baseline and a changelog line, exactly like the piecewise fix. Say the word and I will open it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns configuration and ground truth alongside generated data via `simulate()`, enabling validation and reproducibility. Previously generators returned only a DataFrame; now `SimulationResult` adds `config` and `truth` without changing generator outputs.

- `simulate(model, **kwargs)` returns `SimulationResult` with:
  - `data`: exactly what `generate()`/`gen_*` returned before.
  - `config`: `SimulationConfig` (model, params incl. seed, `gen_surv` version) for reproducible scenarios; `.replace()`/`.run()` helpers and `to_dict()`/`from_dict()`.
  - `truth`: shared keys (`beta`/`betas`, `covariates`, `linear_predictor`, `event_time`, `censoring_time`) plus model-specific ones (e.g., `cause_times`, `transition_times`, `cured`, `crossover_time` for `tdcm`, `baseline` for recurrent). `truth_frame()` returns per-subject entries aligned with subjects.
- All twelve generators now call an internal `record()` to populate truth. Outside capture it’s a no-op, so `gen_*` signatures and outputs are unchanged; frozen baselines are byte-identical. Capture is isolated per call using a `ContextVar`.
- Randomly drawn coefficients (when omitted by the caller) are now recorded, removing a major validation blind spot.
- New docs: guide and API for simulation results; exports `simulate`, `SimulationConfig`, `SimulationResult` from `gen_surv`.

**Review notes**
- Focus on `gen_surv/results.py` and `gen_surv/_truth.py`, and the one-line `record()` additions in each generator.
- Concurrency safety: truth capture cannot leak across threads/tasks.
- Separate and not fixed here: a sign error identified in `tdcm` post-crossover inversion; will require its own PR due to seeded output change.

<sup>Written for commit b6eaf20c62817d3363a8af356aab8fb5903fb5ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

