### PR TITLE
chore(release): prepare 2.1.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
   "title": "gen_surv: Survival Data Simulation in Python",
   "upload_type": "software",
-  "version": "2.0.1",
-  "publication_date": "2026-08-23",
+  "version": "2.1.0",
+  "publication_date": "2026-08-24",
   "description": "<p><strong>gen_surv</strong> generates synthetic time-to-event datasets from twelve models &mdash; proportional hazards, accelerated failure time, competing risks, cure fractions, piecewise hazards, recurrent events and two illness-death processes &mdash; so that an estimator can be tested against parameters the user chose. Alongside the data it can return the ground truth a real dataset could never contain: the coefficients actually used, latent event and censoring times, cure status and transition times. Inspired by the R package <a href=\"https://cran.r-project.org/package=genSurv\">genSurv</a> and extended well past it.</p>",
   "creators": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,107 @@
 # CHANGELOG
 
+## v2.1.0 (2026-08-24)
+
+A twelfth model, the configuration and ground truth behind every dataset, a
+baseline hazard abstraction, and two sampler corrections. The documentation is
+rebuilt from scratch on MkDocs; the API reference on the published site had
+been empty since it was written.
+
+**Two generators produce different data for the same seed** than they did in
+2.0.1: `piecewise_exponential` with two or more breakpoints, and `tdcm`. Both
+were producing wrong data, described below. Pin the version alongside the seed
+if you need to reproduce earlier results.
+
+### Features
+- **`gen_recurrent_events`**, a twelfth model, for events that repeat within a
+  subject. Three processes matching the models the data is analysed with:
+  `ag` (Andersen-Gill), and `pwp_tt` and `pwp_gt` (Prentice-Williams-Peterson
+  in total and gap time, the latter resetting the clock at each event).
+  Exponential, Weibull and Gompertz baselines. Returns counting-process
+  intervals with an `enum` column.
+- **`simulate()`**, returning a `SimulationResult`: the frame, the
+  `SimulationConfig` that produced it — parameters, seed and the `gen_surv`
+  version — and a `truth` mapping of what a real dataset could never contain.
+  Coefficients actually used, covariates, linear predictors, latent event and
+  censoring times, cure status, cause-specific and transition times, and the
+  `tdcm` crossover time the frame cannot express. All twelve generators report.
+
+  Most useful where several generators **draw their coefficients when the
+  caller omits them**: there was previously no way to learn what they were,
+  which quietly made those datasets useless for validating an estimator.
+- **`gen_surv.baseline`**, a `BaselineHazard` protocol with `hazard`,
+  `cumulative_hazard` and its inverse, implemented for exponential, Weibull,
+  Gompertz, log-logistic and piecewise-constant hazards. A generator written
+  against it accepts any shape: `gen_recurrent_events` takes a name or an
+  object, so it already samples from families it does not name.
+- The CLI can reach every registered model. `cmm`, `thmm` and `tdcm` had no way
+  to pass their parameters and failed with a `TypeError`, while being
+  advertised as valid values of `MODEL`. Adds `--rate`, `--dist`, `--corr`,
+  `--dist-par` and `--lam`.
+
+### Bug Fixes
+- **`gen_piecewise_exponential` drew middle-interval events at the wrong
+  hazard.** The inversion assigned the event time and broke out of the loop,
+  but the trailing "no event yet" branch ran anyway and overwrote it using the
+  *last* rate. With breakpoints `[1, 3]` and rates `[0.5, 2.0, 0.2]`, the
+  hazard measured on `[1, 3)` was 0.201 against a declared 2.0. Only
+  specifications with two or more breakpoints were affected.
+- **`gen_tdcm` had a sign error in its post-crossover inversion**, placing
+  events drawn after the covariate switch *before* it and, for a large enough
+  `beta[1]`, at negative times: 6886 of 50000 subjects at `beta[1] = 1.0`. The
+  hazard ratio across the switch measured 4.58 where `exp(beta[1])` was 2.0.
+- **`tdcov` described the wrong interval.** It was set from the branch the
+  event time was drawn on, so a subject censored before its crossover was
+  recorded as having switched though its covariate never did while observed. It
+  is now whether the crossover was reached by the observed exit.
+- **`summarize_survival_dataset` crashed on Windows.** Its verbose report, the
+  default, printed check and cross marks that a console on a legacy code page
+  cannot encode, raising `UnicodeEncodeError` before printing anything.
+- **`GenSurvDataGenerator` was not scikit-learn compatible.** `get_params`
+  reported only `model` and `return_type`, so `set_params` raised on any model
+  argument and `clone` — used internally by pipelines, `GridSearchCV` and
+  `cross_val_score` — silently dropped every parameter, producing an estimator
+  that failed on first use.
+
+### Documentation
+- Rebuilt on **MkDocs** with Material and mkdocstrings, replacing Sphinx.
+  `docs/source/api/index.md` had been written in mkdocstrings syntax, which
+  Sphinx rendered as literal YAML, so **the published API reference contained
+  no signatures and no docstrings at all**. Read the Docs is retired; the
+  GitHub Pages site, built from the release tag, is the single home.
+- Rewritten rather than ported: per-model pages with parameters, mathematics, a
+  worked example and a check that the parameters can be recovered; guides for
+  baselines, ground truth, censoring, covariates, summaries, plotting, export,
+  interoperability and the CLI; a full API reference over every public module.
+- Three docstrings in `gen_surv/aft.py` indented their `Returns` and `Examples`
+  sections six spaces instead of four, so numpydoc never parsed them and
+  neither rendered.
+- The example scripts and Binder notebooks are repaired. Two passed a `qmat`
+  argument removed long ago, one of them describing the Gaussian-emission
+  hidden Markov model that was never implemented; two passed a deprecated third
+  coefficient to `gen_tdcm`; and all three notebooks called `np.random.seed`,
+  which no generator reads, so they were not reproducible.
+
+### Testing
+- The frozen-output regression suite **had been inert**: `tests/baselines` was
+  empty, so every case hit a `pytest.skip` and the run reported success while
+  comparing against nothing, and it covered four of twelve generators.
+  Baselines are committed for all twelve, a missing one now fails, and the
+  tolerance is tightened from `1e-6` to `1e-12`.
+- **Distribution tests for every generator**, by probability integral
+  transform, closing the roadmap's highest-priority gap.
+- The documentation's examples are executed and their pasted output compared
+  against what they print, and the example scripts and notebooks are run.
+
+### Packaging
+- Metadata migrated to PEP 621 `[project]`, clearing three Poetry deprecations.
+  The wheel gains `License-Expression: MIT` and ships `LICENSE`.
+- `poetry.lock` is committed, which makes CI reproducible and gives five cache
+  keys that had never varied something to hash. Three workflows depended on it
+  being tracked and had therefore never done anything.
+- Removes the `[tool.semantic_release]` configuration no workflow read, and the
+  `python-semantic-release` dependency that served it.
+
 ## v2.0.1 (2026-08-23)
 
 No library changes: `gen_surv` behaves exactly as it does in v2.0.0. This release

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ message: "If you use this software, please cite it using the metadata below."
 preferred-citation:
   type: software
   title: "gen_surv"
-  version: "2.0.1"
+  version: "2.1.0"
   url: "https://github.com/DiogoRibeiro7/genSurvPy"
   authors:
     - family-names: Ribeiro
@@ -15,5 +15,5 @@ preferred-citation:
       affiliation: "ESMAD - Instituto Politécnico do Porto"
       email: "dfr@esmad.ipp.pt"
   license: "MIT"
-  date-released: "2026-08-23"
+  date-released: "2026-08-24"
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ A bug fix in a sampler changes the draws a seed produces, so **pin the version
 alongside the seed** for anything that must reproduce:
 
 ```text
-gen-surv==2.0.1
+gen-surv==2.1.0
 ```
 
 See
@@ -250,7 +250,7 @@ Work happens on `develop`; `main` carries releases. See
   title   = {gen_surv: Survival Data Simulation in Python},
   author  = {Diogo Ribeiro},
   url     = {https://github.com/DiogoRibeiro7/genSurvPy},
-  version = {2.0.1}
+  version = {2.1.0}
 }
 ```
 

--- a/docs/getting-started/reproducibility.md
+++ b/docs/getting-started/reproducibility.md
@@ -113,7 +113,7 @@ change the data a given seed produces. That has already happened: the 1.3.0 and
 **If a result must be reproducible for a paper, pin the version:**
 
 ```
-gen-surv==2.0.1
+gen-surv==2.1.0
 ```
 
 and record it alongside the seed. Record both in the artefact itself where you

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,7 +143,7 @@ Several models draw their coefficients for you when you omit them, and
   title   = {gen_surv: Survival Data Simulation in Python},
   author  = {Diogo Ribeiro},
   url     = {https://github.com/DiogoRibeiro7/genSurvPy},
-  version = {2.0.1}
+  version = {2.1.0}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen_surv"
-version = "2.0.1"
+version = "2.1.0"
 description = "Simulate survival data with a known truth: twelve models spanning proportional hazards, accelerated failure time, competing risks, cure fractions, recurrent events and multi-state processes"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
Prepares **2.1.0**. Stacked on #169 — merge that first and this reduces to one commit.

## Why now, beyond the changelog

**The published documentation is still the old Sphinx site.** The Pages workflow builds from the release tag, so everything written since 2.0.1 is unpublished:

```
$ curl -s https://diogoribeiro7.github.io/genSurvPy/ | grep -o "<title>.*</title>"
<title>gen_surv: Survival Data Simulation in Python &mdash; gen_surv 2.0.1 documentation</title>
```

That is the Sphinx theme, serving the API reference that contains no signatures. Cutting the release is what replaces it.

Two shipped correctness bugs are also unreleased: the piecewise middle-interval hazard and the `tdcm` sign error that produced negative survival times.

## Why minor rather than patch

It adds a twelfth generator, a public `simulate()` returning configuration and ground truth, and the `gen_surv.baseline` protocol with five hazard families.

**Two generators produce different data for the same seed** — `piecewise_exponential` with two or more breakpoints, and `tdcm` — because both were producing wrong data. That follows 1.3.0, which corrected the bivariate sampler as a minor release. Nothing changes shape or column names, so no existing analysis code breaks; the changelog states the reproducibility break plainly at the top.

## Contents

| | |
|---|---|
| **Features** | `gen_recurrent_events`; `simulate()` / `SimulationConfig` / `SimulationResult`; `gen_surv.baseline`; the CLI reaching all twelve models |
| **Fixes** | piecewise middle-interval hazard; `tdcm` sign error and `tdcov` semantics; `summarize_survival_dataset` crashing on Windows; `GenSurvDataGenerator` not surviving `clone` |
| **Docs** | MkDocs, rewritten; the API reference renders for the first time |
| **Testing** | regression baselines for all twelve (they had been skipping); distribution tests for all twelve; documentation examples and their outputs executed |
| **Packaging** | PEP 621; `poetry.lock` committed; `python-semantic-release` removed |

## Verification

- Version consistent across all five files that carry it — checked with the same script `publish.yml` runs.
- 532 passed, 0 skipped. `poetry check --lock` clean. `mkdocs build --strict` clean. black, isort, flake8, mypy pass.

## The classifier stays at 4 - Beta

Distribution tests for all twelve generators were its stated blocker and have shipped, but R parity fixtures and wider property-based testing have not — and this cycle turned up three more defects on its way in. Not yet the profile of a package claiming production stability.

## After this merges

`develop` → `main` (**merge commit**, not squash, or the next release PR conflicts again), tag `v2.1.0`, dispatch `publish.yml` from `main`, then publish the GitHub Release — which fires the Pages workflow and finally puts the new documentation live. I can drive all of that once the two merges are in.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare `gen_surv` 2.1.0 by bumping versions/dates across metadata and updating doc snippets, plus adding the 2.1.0 changelog. This release is required to publish the new MkDocs site and ships two correctness fixes that change seeded outputs for `piecewise_exponential` (≥2 breakpoints) and `tdcm`.

- Updates `pyproject.toml`, `CITATION.cff`, `.zenodo.json`, `README.md`, and docs to 2.1.0 dated 2026-08-24; adds the 2.1.0 changelog describing `gen_recurrent_events`, `simulate()`, `gen_surv.baseline`, and fixes.

- If you need reproducibility, pin `gen-surv==2.1.0`. Seeds from 2.0.1 will not reproduce for the two corrected generators.

- After merge: merge `develop` into `main` as a merge commit, tag `v2.1.0`, dispatch `publish.yml` from `main`, then publish the GitHub Release to trigger Pages and publish the new docs.

<sup>Written for commit 7f1d09eeff702e9286788a05f1bc62dcc4acf8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

