### PR TITLE
fix: reject NaN and infinity in every numeric argument

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,9 +55,23 @@ items here are about finding the ones that have not been.
 - [ ] **Wider property-based testing.** Hypothesis is already used in a few
       places; extend it to parameter validation and invariants across all
       generators. Complements the statistical tests rather than replacing them.
-- [ ] **Centralised parameter validation.** Finite and positive checks are
-      applied inconsistently, so some invalid values still reach NumPy and
-      surface as confusing downstream errors.
+- [x] **Centralised parameter validation.** Finiteness is now checked where
+      positivity is. The inconsistency had a single cause: every comparison
+      with NaN is false, so `value <= 0` admitted it, and `inf > 0` is true.
+      `ensure_positive_sequence` had guarded against both; the scalar
+      `ensure_positive` had not.
+
+      Probing all twelve generators with NaN and infinity in every numeric
+      argument found **39 that were accepted**. They came back as a frame of
+      the right shape quietly full of NaN, as `OverflowError: high - low range
+      exceeds valid bounds` from a uniform draw, or — for
+      `gen_recurrent_events(followup_time=nan)` — as a call that never
+      returned, the sampling loop comparing candidates against a bound nothing
+      can exceed. `cmm` and `thmm` also checked only the *length* of `rate`, so
+      a negative entry surfaced as `ValueError: scale < 0` from inside NumPy.
+
+      All rejected now, with `tests/test_input_hardening.py` walking every
+      numeric argument of every model to keep it that way.
 - [ ] **Return the maturity classifier to `5 - Production/Stable`** once the
       items above are in place. Distribution tests have now shipped for all
       twelve generators, which was the stated blocker; R parity fixtures and

--- a/gen_surv/cphm.py
+++ b/gen_surv/cphm.py
@@ -121,7 +121,7 @@ def gen_cphm(
     1  0.78     0.0       0.89
     ...
     """
-    validate_gen_cphm_inputs(n, model_cens, cens_par, covariate_range)
+    validate_gen_cphm_inputs(n, model_cens, cens_par, covariate_range, beta)
 
     rfunc = {"uniform": runifcens, "exponential": rexpocens}[model_cens]
 

--- a/gen_surv/validation.py
+++ b/gen_surv/validation.py
@@ -6,6 +6,7 @@ checks used by the data generators.
 
 from __future__ import annotations
 
+import math
 import warnings
 from collections.abc import Sequence
 from numbers import Integral, Real
@@ -115,19 +116,39 @@ def ensure_positive_int(value: int, name: str) -> None:
         raise PositiveIntegerError(name, value)
 
 
+def ensure_finite(value: float | int, name: str) -> None:
+    """Ensure ``value`` is a real number that is neither NaN nor infinite.
+
+    Every comparison with NaN is false, so a check written as ``value <= 0``
+    silently admits it, and ``inf > 0`` is true. Both then reach NumPy, where
+    they either surface as an unrelated error -- ``OverflowError: high - low
+    range exceeds valid bounds`` from a uniform draw -- or produce a frame
+    quietly full of NaN. Rejecting them here is what makes the message name the
+    argument the caller got wrong.
+    """
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise ParameterError(name, value, "must be a number")
+    if not math.isfinite(float(value)):
+        raise ParameterError(name, value, "must be a finite number")
+
+
 def ensure_positive(value: float | int, name: str) -> None:
-    """Ensure ``value`` is a positive number."""
-    if not isinstance(value, Real) or isinstance(value, bool) or value <= 0:
+    """Ensure ``value`` is a finite positive number."""
+    if not isinstance(value, Real) or isinstance(value, bool):
+        raise PositiveValueError(name, value)
+    if not math.isfinite(float(value)):
+        # A separate message: NaN and infinity are numbers, and saying so is
+        # more use than "must be greater than 0" for a value no comparison
+        # would have caught.
+        raise ParameterError(name, value, "must be a finite number")
+    if value <= 0:
         raise PositiveValueError(name, value)
 
 
 def ensure_probability(value: float | int, name: str) -> None:
     """Ensure ``value`` lies in the closed interval [0, 1]."""
-    if (
-        not isinstance(value, Real)
-        or isinstance(value, bool)
-        or not (0 <= float(value) <= 1)
-    ):
+    ensure_finite(value, name)
+    if not (0 <= float(value) <= 1):
         raise ParameterError(name, value, "must be between 0 and 1")
 
 
@@ -205,7 +226,11 @@ def ensure_numeric_sequence(seq: Sequence[Any], name: str) -> None:
     NumericSequenceError
         If any element cannot be interpreted as a numeric value.
     """
-    _to_float_array(seq, name)
+    arr = _to_float_array(seq, name)
+    bad = np.where(~np.isfinite(arr))[0]
+    if bad.size:
+        idx = int(bad[0])
+        raise ParameterError(f"{name}[{idx}]", seq[idx], "must be a finite number")
 
 
 def ensure_positive_sequence(seq: Sequence[float], name: str) -> None:
@@ -337,11 +362,22 @@ def _validate_covariate_inputs(
 
 
 def validate_gen_cphm_inputs(
-    n: int, model_cens: str, cens_par: float, covariate_range: float
+    n: int,
+    model_cens: str,
+    cens_par: float,
+    covariate_range: float,
+    beta: float | None = None,
 ) -> None:
-    """Validate input parameters for CPHM data generation."""
+    """Validate input parameters for CPHM data generation.
+
+    ``beta`` is a log hazard ratio and may be any sign, so no positivity check
+    reaches it. It still has to be a finite number: NaN propagates into every
+    drawn time, and the frame comes back the right shape and entirely NaN.
+    """
     _validate_base(n, model_cens, cens_par)
     ensure_positive(covariate_range, "covariate_range")
+    if beta is not None:
+        ensure_finite(beta, "beta")
 
 
 def validate_gen_cmm_inputs(
@@ -357,6 +393,10 @@ def validate_gen_cmm_inputs(
     _validate_beta(beta)
     ensure_positive(covariate_range, "covariate_range")
     ensure_sequence_length(rate, _CMM_RATE_LEN, "rate")
+    # Only the length was checked. A negative entry reached NumPy and surfaced
+    # as "ValueError: scale < 0" from inside the generator; NaN passed straight
+    # through into every drawn time.
+    ensure_positive_sequence(rate, "rate")
 
 
 def validate_gen_tdcm_inputs(
@@ -404,6 +444,7 @@ def validate_gen_thmm_inputs(
     _validate_beta(beta)
     ensure_positive(covariate_range, "covariate_range")
     ensure_sequence_length(rate, _THMM_RATE_LEN, "rate")
+    ensure_positive_sequence(rate, "rate")
 
 
 def validate_dg_biv_inputs(

--- a/tests/test_competing_risks.py
+++ b/tests/test_competing_risks.py
@@ -136,7 +136,9 @@ def test_competing_risks_invalid_covariate_params():
 def test_competing_risks_invalid_beta_values():
     with pytest.raises(NumericSequenceError):
         gen_competing_risks(n=5, n_risks=2, betas=[[0.1, "x"], [0.2, 0.3]], seed=0)
-    with pytest.raises(NumericSequenceError):
+    # NaN is numeric, so NumericSequenceError named the wrong problem. It is
+    # now reported as a non-finite value, with the offending index.
+    with pytest.raises(ParameterError, match="finite"):
         gen_competing_risks_weibull(
             n=5, n_risks=2, betas=[[0.1, np.nan], [0.2, 0.3]], seed=0
         )

--- a/tests/test_input_hardening.py
+++ b/tests/test_input_hardening.py
@@ -1,0 +1,224 @@
+"""Every generator must reject NaN and infinity in every numeric argument.
+
+Comparisons with NaN are all false, so a check written as ``value <= 0``
+silently admits it, and ``inf > 0`` is true. Both then reach NumPy. What came
+back was one of three things, none of them an error the caller could act on:
+
+- a frame of the right shape, quietly full of NaN;
+- ``OverflowError: high - low range exceeds valid bounds`` from a uniform draw,
+  naming nothing the caller passed;
+- for ``gen_recurrent_events(followup_time=nan)``, a call that never returned,
+  because the sampling loop compares each candidate event time against a bound
+  that no value can exceed.
+
+Thirty-nine arguments across the twelve generators were affected. These tests
+walk every numeric argument of every model and require a ``ValidationError``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from gen_surv import generate
+from gen_surv.validation import (
+    ParameterError,
+    PositiveValueError,
+    ValidationError,
+    ensure_finite,
+    ensure_positive,
+)
+
+# A valid call for every registered model, kept small: these tests are about
+# rejection, so nothing needs to be large.
+VALID_CALLS: dict[str, dict[str, Any]] = {
+    "cphm": dict(
+        n=20, beta=0.5, covariate_range=2.0, model_cens="uniform", cens_par=1.0
+    ),
+    "aft_ln": dict(n=20, beta=[0.5], sigma=1.0, model_cens="uniform", cens_par=1.0),
+    "aft_weibull": dict(
+        n=20, beta=[0.5], shape=1.5, scale=2.0, model_cens="uniform", cens_par=1.0
+    ),
+    "aft_log_logistic": dict(
+        n=20, beta=[0.5], shape=1.5, scale=2.0, model_cens="uniform", cens_par=1.0
+    ),
+    "piecewise_exponential": dict(
+        n=20, breakpoints=[1.0], hazard_rates=[0.5, 1.0], betas=[0.1, 0.1]
+    ),
+    "competing_risks": dict(
+        n=20, n_risks=2, baseline_hazards=[0.4, 0.2], betas=[[0.1, 0.0], [0.0, 0.1]]
+    ),
+    "competing_risks_weibull": dict(
+        n=20, n_risks=2, shape_params=[1.2, 0.8], scale_params=[2.0, 1.5]
+    ),
+    "mixture_cure": dict(
+        n=20,
+        cure_fraction=0.3,
+        baseline_hazard=0.5,
+        betas_survival=[0.1, 0.1],
+        betas_cure=[0.1, 0.1],
+    ),
+    "cmm": dict(
+        n=20,
+        model_cens="uniform",
+        cens_par=1.0,
+        beta=[0.1, 0.2, 0.3],
+        covariate_range=1.0,
+        rate=[0.1, 1.0, 0.2, 1.0, 0.1, 1.0],
+    ),
+    "thmm": dict(
+        n=20,
+        model_cens="uniform",
+        cens_par=1.0,
+        beta=[0.1, 0.2, 0.3],
+        covariate_range=1.0,
+        rate=[0.2, 0.3, 0.4],
+    ),
+    "tdcm": dict(
+        n=20,
+        dist="weibull",
+        corr=0.5,
+        dist_par=[1.0, 2.0, 1.0, 2.0],
+        model_cens="uniform",
+        cens_par=1.0,
+        beta=[0.5, 0.3],
+        lam=1.0,
+    ),
+    "recurrent_events": dict(
+        n=20,
+        baseline_params={"rate": 0.5},
+        betas=[0.1, 0.1],
+        followup_time=5.0,
+        cens_par=8.0,
+    ),
+}
+
+HOSTILE = [float("nan"), float("inf"), float("-inf")]
+
+
+def _scalar_arguments(call: dict[str, Any]) -> list[str]:
+    return [
+        key
+        for key, value in call.items()
+        if isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and key != "n"
+    ]
+
+
+def _sequence_arguments(call: dict[str, Any]) -> list[str]:
+    return [key for key, value in call.items() if isinstance(value, list) and value]
+
+
+def test_every_model_has_a_valid_call_here() -> None:
+    from gen_surv.interface import _model_map
+
+    assert set(VALID_CALLS) == set(_model_map), "a model was added without a case"
+
+
+@pytest.mark.parametrize("model", sorted(VALID_CALLS))
+def test_valid_call_still_works(model: str) -> None:
+    """The baseline each hostile case is derived from must itself be valid."""
+    assert len(generate(model=model, **VALID_CALLS[model], seed=1)) > 0
+
+
+@pytest.mark.parametrize("model", sorted(VALID_CALLS))
+def test_non_finite_scalars_are_rejected(model: str) -> None:
+    call = VALID_CALLS[model]
+
+    for argument in _scalar_arguments(call):
+        for hostile in HOSTILE:
+            kwargs = {**call, argument: hostile, "seed": 1}
+            with pytest.raises(ValidationError):
+                generate(model=model, **kwargs)
+
+
+@pytest.mark.parametrize("model", sorted(VALID_CALLS))
+def test_non_finite_sequence_entries_are_rejected(model: str) -> None:
+    call = VALID_CALLS[model]
+
+    for argument in _sequence_arguments(call):
+        for hostile in (float("nan"), float("inf")):
+            poisoned = list(call[argument])
+            if isinstance(poisoned[0], list):
+                poisoned[0] = [hostile, *poisoned[0][1:]]
+            else:
+                poisoned[0] = hostile
+
+            kwargs = {**call, argument: poisoned, "seed": 1}
+            with pytest.raises(ValidationError):
+                generate(model=model, **kwargs)
+
+
+@pytest.mark.parametrize("model", ["cmm", "thmm"])
+def test_negative_transition_rates_are_rejected(model: str) -> None:
+    """Only the length of ``rate`` was checked.
+
+    A negative entry reached NumPy and surfaced as ``ValueError: scale < 0``
+    from inside the random generator, naming nothing the caller had passed.
+    """
+    call = dict(VALID_CALLS[model])
+    call["rate"] = [
+        -abs(value) if index == 0 else value for index, value in enumerate(call["rate"])
+    ]
+
+    with pytest.raises(ValidationError, match="rate"):
+        generate(model=model, **call, seed=1)
+
+
+def test_recurrent_events_with_a_nan_horizon_returns(monkeypatch) -> None:
+    """This call used to hang rather than raise.
+
+    ``followup_time=nan`` made every ``candidate >= end`` comparison false, so
+    the sampling loop had no exit and ran until the process was killed.
+    """
+    with pytest.raises(ValidationError):
+        generate(
+            model="recurrent_events",
+            n=5,
+            followup_time=float("nan"),
+            betas=[0.1, 0.1],
+            seed=1,
+        )
+
+
+# --------------------------------------------------------------------------
+# The helpers themselves
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_ensure_positive_rejects_non_finite(value: float) -> None:
+    with pytest.raises(ParameterError, match="finite"):
+        ensure_positive(value, "value")
+
+
+def test_ensure_positive_keeps_its_existing_contract() -> None:
+    """A bool or a non-number is still a PositiveValueError, as before."""
+    ensure_positive(0.1, "value")
+
+    with pytest.raises(PositiveValueError):
+        ensure_positive(True, "value")
+    with pytest.raises(PositiveValueError):
+        ensure_positive(-1.0, "value")
+    with pytest.raises(PositiveValueError):
+        ensure_positive(0.0, "value")
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_ensure_finite_rejects_non_finite(value: float) -> None:
+    with pytest.raises(ParameterError, match="finite"):
+        ensure_finite(value, "value")
+
+
+def test_ensure_finite_accepts_any_finite_sign() -> None:
+    for value in (-3.5, 0.0, 2.75):
+        ensure_finite(value, "value")
+        assert math.isfinite(value)
+
+
+def test_ensure_finite_rejects_a_bool_as_a_number() -> None:
+    with pytest.raises(ParameterError, match="number"):
+        ensure_finite(True, "value")


### PR DESCRIPTION
The roadmap's **centralised parameter validation** item, which turned out to have a single cause.

## One line

Every comparison with NaN is false, so a check written as `value <= 0` admits it, and `inf > 0` is true. `ensure_positive_sequence` guarded against both with an `isfinite` test. The scalar `ensure_positive` did not — and everything funnels through it.

## What got through

Probing all twelve generators with NaN and infinity in every numeric argument found **39 accepted**. They came back as one of three things, none of them an error a caller could act on:

| Symptom | Examples |
|---|---|
| A frame of the right shape, **quietly full of NaN** | `aft_weibull(scale=nan)`, `mixture_cure(baseline_hazard=nan)`, `tdcm(lam=nan)`, `cphm(beta=nan)` |
| `OverflowError: high - low range exceeds valid bounds`, from a uniform draw, naming nothing the caller passed | `cens_par` and `covariate_range` across five models |
| **A call that never returns** | `gen_recurrent_events(followup_time=nan)` |

That last one is the sharpest: every `candidate >= end` comparison is false against NaN, so the sampling loop had no exit. It ran until I killed the process — which is how I found it, when the probe itself timed out.

`cmm` and `thmm` additionally checked only the **length** of `rate`, never its contents, so a negative entry surfaced as `ValueError: scale < 0` from inside `numpy.random._common`.

## The fix

- `ensure_positive` checks finiteness, with a message that says so rather than "must be greater than 0" for a value no comparison would have caught.
- A new `ensure_finite` covers arguments with no sign constraint. `cphm`'s `beta` is a log hazard ratio, so **nothing had been validating it at all**.
- `ensure_numeric_sequence` rejects non-finite entries, naming the index.
- The two multistate validators check their rate vectors.

After: **0 of 39 accepted.**

## One deliberate behaviour change

A NaN among `betas` was reported as `NumericSequenceError`, which named the wrong problem — NaN *is* numeric. It is now a `ParameterError` saying "must be a finite number", with the index. One test updated to match.

`ensure_positive` keeps its existing contract for a bool or a non-number: still `PositiveValueError`, so nothing else moves.

## Tests

`tests/test_input_hardening.py` walks every numeric argument of every model, scalar and sequence, and requires a `ValidationError` — 49 cases. A further test fails if a model is registered without a case here, so a new generator cannot arrive unprobed.

Verified to bite: reverting the `cphm` change alone makes that model's case fail, and restoring it passes.

## Verification

581 passed, 0 skipped. black, isort, flake8, mypy pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects NaN and infinity in all numeric arguments to prevent silent NaNs, unrelated `numpy` errors, and hangs. Previously, `ensure_positive` let NaN/∞ through (NaN bypassed comparisons; ∞ > 0), so 39 invalid cases were accepted; now all are rejected with clear validation errors.

- Adds `ensure_finite` and updates `ensure_positive` to enforce finiteness with a “must be a finite number” message.
- `ensure_numeric_sequence` now rejects non-finite entries and reports the offending index.
- Validates multistate `rate` contents in `cmm` and `thmm` (not just length) using `ensure_positive_sequence`.
- `validate_gen_cphm_inputs` now accepts `beta` and validates it as finite; call site updated.
- Intentional behavior change: a NaN in `betas` raises `ParameterError` (was `NumericSequenceError`).
- Adds `tests/test_input_hardening.py` to probe every generator arg for non-finite values; updates `tests/test_competing_risks.py`; documents roadmap completion in `TODO.md`.

**Migration**
- Calls that previously passed NaN/∞ will now raise `ValidationError`; provide finite values.
- If calling `validate_gen_cphm_inputs` directly, pass `beta` (or omit to skip) to match the new signature.

<sup>Written for commit 0fb9e45dcd89e85bee909cd9b56f7ef54d022b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

