### PR TITLE
feat: ship py.typed so the annotations reach downstream users

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -88,8 +88,14 @@ items here are about finding the ones that have not been.
       `pyreadr` are mandatory today, so simulating a Weibull dataset pulls in a
       plotting stack and two file-format libraries. Move them behind `viz`, `io`
       and `sklearn` extras with `all` as a convenience.
-- [ ] **Add `py.typed`** so downstream users get the annotations that are already
-      written and checked.
+- [x] **Added `py.typed`.** The annotations were written and mypy checked them
+      on every commit, but PEP 561 tells a type checker to ignore an installed
+      package's inline types without the marker, so none of it reached anyone.
+      A downstream `mypy` reported `Cannot find implementation or library stub
+      for module named "gen_surv"` and silently accepted
+      `gen_cphm(n="not an integer", ...)`; it now reports the argument type.
+      Measured by installing the built wheel into a clean environment and
+      running mypy over a downstream file, before and after.
 
 ## Repository hygiene
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,74 @@
+"""The package must advertise its type information to downstream users.
+
+`gen_surv` is fully annotated and mypy runs over it on every commit, but none of
+that reached anyone installing it. Without a `py.typed` marker, PEP 561 tells a
+type checker to ignore an installed package's inline annotations, so a
+downstream `mypy` reported
+
+    error: Cannot find implementation or library stub for module named "gen_surv"
+
+and silently accepted `gen_cphm(n="not an integer", ...)`. With the marker, the
+same call is reported as `Argument "n" ... has incompatible type "str";
+expected "int"`.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+
+import gen_surv
+
+
+def _package_root() -> pathlib.Path:
+    assert gen_surv.__file__ is not None
+    return pathlib.Path(gen_surv.__file__).parent
+
+
+def test_py_typed_marker_ships_with_the_package() -> None:
+    """Checked on the imported package, so an install without it fails too."""
+    marker = _package_root() / "py.typed"
+
+    assert marker.is_file(), (
+        "gen_surv/py.typed is missing. Without it a type checker ignores every "
+        "annotation in the package, whatever the source says."
+    )
+
+
+def test_the_public_api_is_actually_annotated() -> None:
+    """A marker promising types that are not there would be worse than none."""
+    unannotated: list[str] = []
+
+    for name in gen_surv.__all__:
+        obj = getattr(gen_surv, name, None)
+        if not (inspect.isfunction(obj) or inspect.isclass(obj)):
+            continue
+        try:
+            signature = inspect.signature(obj)
+        except (TypeError, ValueError):  # pragma: no cover - builtins
+            continue
+
+        for parameter in signature.parameters.values():
+            if parameter.name in ("self", "cls", "args", "kwargs"):
+                continue
+            if parameter.annotation is inspect.Parameter.empty:
+                unannotated.append(f"{name}({parameter.name})")
+
+    assert not unannotated, f"unannotated public parameters: {unannotated}"
+
+
+def test_public_functions_declare_a_return_type() -> None:
+    missing: list[str] = []
+
+    for name in gen_surv.__all__:
+        obj = getattr(gen_surv, name, None)
+        if not inspect.isfunction(obj):
+            continue
+        try:
+            signature = inspect.signature(obj)
+        except (TypeError, ValueError):  # pragma: no cover - builtins
+            continue
+        if signature.return_annotation is inspect.Signature.empty:
+            missing.append(name)
+
+    assert not missing, f"public functions without a return annotation: {missing}"


### PR DESCRIPTION
One empty file, with a measurable effect.

Every public function is annotated and mypy checks them on every commit — but **none of that reached anyone installing the package.** PEP 561 tells a type checker to ignore an installed package's inline annotations unless it ships a `py.typed` marker.

## Before

A downstream file, in a clean virtual environment with the built wheel installed:

```python
from gen_surv import gen_cphm

frame = gen_cphm(
    n="not an integer",       # wrong: n is int
    model_cens="uniform", cens_par=1.0, beta=0.5, covariate_range=2.0,
)
```

```
user_code.py:2: error: Cannot find implementation or library stub for module named "gen_surv"
Found 1 error in 1 file
```

The wrong argument passes unnoticed; the package is invisible to the type checker.

## After

```
user_code.py:5: error: Argument "n" to "gen_cphm" has incompatible type "str"; expected "int"
Found 1 error in 1 file
```

## Measured, not assumed

Built the wheel, installed it into a clean venv with mypy, and type-checked a downstream file **from outside the repository**. My first attempt ran from the repo root and proved nothing — mypy reads the source there regardless of what the installed package advertises, which is exactly the trap that makes this gap easy to miss locally.

Confirmed `gen_surv/py.typed` is inside the built wheel, not merely in the source tree.

## What a user actually gets

Argument checking on every call, and return types wherever they do not bottom out in pandas:

```
reveal_type(WeibullBaseline(shape=1.5, scale=2.0).cumulative_hazard(1.0))
  -> float | numpy.ndarray[tuple[Any, ...], numpy.dtype[numpy.float64]]

reveal_type(generate(model="cphm", ...))
  -> Any
```

The second stays `Any` because pandas ships no type information; a user wanting it installs `pandas-stubs`. That is outside this package's control, and worth saying plainly rather than claiming full typing.

## Tests

`tests/test_packaging.py` checks the marker on the **imported** package, so an install that failed to include it fails too — and asserts every public parameter and return value really is annotated. A marker promising types that are not there would be worse than no marker.

## Verification

481 passed. black, isort, flake8, mypy pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship `py.typed` with `gen_surv` so downstream type checkers read our inline annotations per PEP 561. Previously, checkers ignored the installed package and accepted wrong arguments; now they surface type errors in user code.

- Include `gen_surv/py.typed` in the built wheel; tests verify the marker on the imported package.
- Assert the public API is actually typed: all exported parameters and function returns have annotations.
- No runtime changes or migrations. For typed DataFrame results, users can install `pandas-stubs`; otherwise those remain Any.

<sup>Written for commit 970dcc81b58117692cda97fe7b5b47c570bd2a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

