### PR TITLE
test: cover the engine's last three lines, and drop a dead branch

### DIFF
--- a/gen_surv/multistate.py
+++ b/gen_surv/multistate.py
@@ -198,12 +198,10 @@ def _walk_cohort(
     state = np.full(n, initial_state, dtype=np.int64)
     entered = np.zeros(n, dtype=float)
     now = np.zeros(n, dtype=float)
+    # Every subject starts in `initial_state`, which _validate_graph has already
+    # refused to accept without an outgoing transition, so all of them are
+    # active to begin with.
     active = np.ones(n, dtype=bool)
-
-    # Absorbing states end follow-up immediately.
-    for label in np.unique(state):
-        if int(label) not in outgoing:
-            active &= state != label
 
     latent = np.full((n, n_transitions), np.nan)
     occupancies: list[

--- a/tests/test_multistate.py
+++ b/tests/test_multistate.py
@@ -281,6 +281,38 @@ def test_a_transition_to_itself_is_rejected() -> None:
         Transition(1, 1, ExponentialBaseline(0.5), [0.0])
 
 
+@pytest.mark.parametrize("label", [1.5, "healthy", None, True])
+def test_a_non_integer_state_label_is_rejected(label: object) -> None:
+    """States are integers; a float or a name would compare unpredictably."""
+    with pytest.raises(ValidationError, match="integer state label"):
+        Transition(label, 2, ExponentialBaseline(0.5), [0.0])  # type: ignore[arg-type]
+
+
+def test_a_runaway_cycle_is_reported_rather_than_hanging(monkeypatch) -> None:
+    """A cycle with a high enough intensity must stop with an error.
+
+    The cap exists so a graph that generates transitions faster than follow-up
+    elapses cannot run forever. It is lowered here rather than building a
+    graph that really would take ten thousand steps.
+    """
+    from gen_surv import multistate
+
+    monkeypatch.setattr(multistate, "_MAX_TRANSITIONS", 3)
+    transitions = [
+        Transition(1, 2, ExponentialBaseline(50.0), [0.0]),
+        Transition(2, 1, ExponentialBaseline(50.0), [0.0]),
+    ]
+
+    with pytest.raises(ValidationError, match="more than 3 transitions"):
+        gen_multistate(
+            n=50,
+            transitions=transitions,
+            cens_par=_NO_CENSORING,
+            max_time=10.0,
+            seed=_SEED,
+        )
+
+
 def test_a_non_baseline_is_rejected() -> None:
     with pytest.raises(ValidationError, match="BaselineHazard"):
         Transition(1, 2, object(), [0.0])  # type: ignore[arg-type]


### PR DESCRIPTION
The `codecov/patch` check on #179 flagged three uncovered lines in the new engine. It was right about all three, and one of them was **dead code**.

## The dead branch

`_walk_cohort` opened by deactivating subjects whose starting state has no outgoing transition:

```python
for label in np.unique(state):
    if int(label) not in outgoing:
        active &= state != label
```

Every subject starts in `initial_state`, and `_validate_graph` has already refused an initial state with no way out. The loop could never fire. Removed rather than tested — shipping unreachable code in a major release is avoidable.

## The two untested paths

- A `Transition` with a **non-integer state label**. Nothing had exercised it, though the check exists because a float or a string state would compare unpredictably against the integer labels everywhere else.
- The **runaway cap** that stops a cyclic graph generating transitions faster than follow-up elapses. Tested by lowering the cap rather than by building a graph that really would take ten thousand steps.

`gen_surv/multistate.py` is now at 100%.

## Why this before the release rather than after

`#179` is `develop` → `main`, so merging this into `develop` carries it into the release automatically. It costs one extra merge and means 3.0.0 ships without a dead branch in its headline feature.

## Verification

558 passed. black, isort, flake8, mypy pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an unreachable pre-deactivation branch in `_walk_cohort` and adds tests for two previously uncovered paths: rejecting non-integer state labels and enforcing the runaway transition cap. Previously, the engine tried to deactivate subjects whose initial state had no outgoing transitions; that check is now deleted because `_validate_graph` already rejects such graphs, so runtime behavior is unchanged.

This restores full coverage for the multistate engine and ensures we don't ship dead code.

<sup>Written for commit 6923d8789be085af2ca788d60fc5b34b544b6b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

