### PR TITLE
docs: propagate the 3.0.0 changes past the multistate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ needed only for the two conversion helpers:
 pip install scikit-survival
 ```
 
+The package ships `py.typed`, so `mypy` and `pyright` check your calls into it
+rather than treating it as untyped.
+
 ## Thirty seconds
 
 ```python
@@ -116,6 +119,37 @@ generates — start at
 > return several rows per subject, and column names differ between families.
 > See [Output schemas](https://diogoribeiro7.github.io/genSurvPy/getting-started/schemas/)
 > before writing code that consumes a generated frame.
+
+## A thirteenth, outside `generate()`
+
+The twelve above each fix a state structure. When yours is not among them,
+`gen_multistate` takes the graph itself:
+
+```python
+from gen_surv import ExponentialBaseline, Transition, WeibullBaseline, gen_multistate
+
+multistate = gen_multistate(
+    n=500,
+    transitions=[
+        Transition(1, 2, WeibullBaseline(shape=1.2, scale=3.0), [0.4]),  # fall ill
+        Transition(2, 1, ExponentialBaseline(rate=0.6), [0.0]),          # recover
+        Transition(2, 3, ExponentialBaseline(rate=0.2), [0.6]),          # die while ill
+    ],
+    clock="reset",
+    seed=1,
+)
+```
+
+Every edge carries its own baseline hazard and coefficients. A state with no
+outgoing edge is absorbing, and cycles are allowed - recovery above is a
+transition like any other. `clock="forward"` measures the hazard from entry to
+the study, giving a Markov process; `clock="reset"` restarts it at each state,
+giving a semi-Markov one.
+
+`cmm` and `thmm` are configurations of this engine rather than separate
+implementations. It takes a list of objects rather than scalars, so it has no
+`model=` string and no command-line form - import it directly. See
+[The multistate engine](https://diogoribeiro7.github.io/genSurvPy/models/multistate/).
 
 ## The ground truth, not just the data
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,6 +79,27 @@ gen_surv --help
 gen_surv dataset cphm --n 5
 ```
 
+## Type checking
+
+The package ships a `py.typed` marker, so a type checker reads the annotations
+on every public function instead of treating the package as untyped:
+
+```python
+from gen_surv import gen_cphm
+
+gen_cphm(n="not an integer", beta=0.5, covariate_range=2.0,
+         model_cens="uniform", cens_par=1.0)
+```
+
+```text
+snippet.py:3: error: Argument "n" to "gen_cphm" has incompatible type "str"; expected "int"  [arg-type]
+Found 1 error in 1 file (checked 1 source file)
+```
+
+Before 3.0.0 the marker was missing, so a type checker reported
+`Cannot find implementation or library stub for module named "gen_surv"` and
+accepted the call above without comment.
+
 ## Building the documentation
 
 This site is built with [MkDocs](https://www.mkdocs.org) and

--- a/docs/getting-started/reproducibility.md
+++ b/docs/getting-started/reproducibility.md
@@ -108,7 +108,11 @@ datasets = [generate(model="cphm", n=500, beta=0.5, covariate_range=2.0,
 
 A bug fix in a sampler changes the draws it makes, so a patch release can
 change the data a given seed produces. That has already happened: the 1.3.0 and
-2.0.0 releases corrected sampling bugs and deliberately changed output.
+2.0.0 releases corrected sampling bugs and deliberately changed output, and
+3.0.0 rebuilt `cmm` and `thmm` on the
+[multistate engine](../models/multistate.md), which draws one candidate per
+outgoing edge per visit where the old implementations drew all three latent
+times up front. Those two generators changed for every seed.
 
 **If a result must be reproducible for a paper, pin the version:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,11 @@ specified.
 | `tdcm` | Cox with a time-dependent covariate | one row per subject | [TDCM](models/tdcm.md) |
 | `recurrent_events` | Repeated events per subject (AG, PWP) | one row per at-risk interval | [Recurrent events](models/recurrent-events.md) |
 
+There is a thirteenth generator that `generate()` cannot reach.
+[`gen_multistate`](models/multistate.md) takes an arbitrary transition graph as
+a list of objects rather than a set of scalars, so it has no `model=` string and
+no command-line form. `cmm` and `thmm` are configurations of it.
+
 Not sure which one you need? [Choosing a model](models/index.md) walks through
 the decision.
 

--- a/docs/models/cmm.md
+++ b/docs/models/cmm.md
@@ -7,6 +7,15 @@ Three states: **1 healthy**, **2 ill**, **3 dead**. A subject starts healthy and
 either falls ill first (`1 → 2`, then possibly `2 → 3`) or dies directly
 (`1 → 3`).
 
+!!! info "Built on the multistate engine"
+
+    Since 3.0.0 this is a configuration of [`gen_multistate`](multistate.md) -
+    the illness-death graph with Weibull edges and a reset clock - rather than a
+    separate implementation. Its columns, dtypes and parameters are unchanged,
+    but **a given seed no longer reproduces its 2.1.0 output**. Reach for the
+    engine directly when you need a state structure this page does not
+    describe.
+
 ```mermaid
 stateDiagram-v2
     direction LR
@@ -153,6 +162,7 @@ For `2 → 3`, remember the clock resets: use `stop - start` as the duration, no
 
 ## Related
 
+- [The multistate engine](multistate.md) — what this model is a configuration of
 - [Illness-death, panel (THMM)](thmm.md) — the same process, observed states
 - [Output schemas](../getting-started/schemas.md#cmm-counting-process-intervals) — every column
 - [Competing risks](competing-risks.md) — `1 → 2` versus `1 → 3` is itself a competing-risks problem

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -35,6 +35,7 @@ flowchart TD
     E --> E1["cmm / thmm<br/>illness-death"]
     E --> E2["tdcm<br/>covariate changes, not the state"]
     E --> E3["recurrent_events<br/>the same event, repeatedly"]
+    E --> E4["gen_multistate<br/>any graph you describe"]
 ```
 
 ## The parameter each model is "about"
@@ -52,6 +53,7 @@ the short version of what to feed an estimator:
 | `cmm` / `thmm` | `rate` per transition | Transitions divided by time at risk in the origin state |
 | `tdcm` | `beta` — baseline and time-dependent effects | Cox model on the `(start, stop]` frame |
 | `recurrent_events` | `betas`, and `stratum_effects` for PWP | Time-varying Cox on the `(start, stop]` frame |
+| `gen_multistate` | one baseline and `coefficients` per edge | Transitions divided by time at risk, per edge |
 
 ## They all share these arguments
 

--- a/docs/models/thmm.md
+++ b/docs/models/thmm.md
@@ -7,6 +7,14 @@ subject's state is recorded.
 "Time-homogeneous" means every transition intensity is constant in time. The
 states are observed, so despite the name this is **not** a hidden Markov model.
 
+!!! info "Built on the multistate engine"
+
+    Since 3.0.0 this is a configuration of [`gen_multistate`](multistate.md) -
+    the illness-death graph with exponential edges and a panel layout - rather
+    than a separate implementation. Its columns, dtypes and id base are
+    unchanged (subjects are still numbered from 1), but **a given seed no longer
+    reproduces its 2.1.0 output**.
+
 ```mermaid
 stateDiagram-v2
     direction LR
@@ -146,6 +154,7 @@ state process. The split mirrors `genCMM` and `genTHMM` in the R package.
 
 ## Related
 
+- [The multistate engine](multistate.md) — what this model is a configuration of
 - [Illness-death, intervals (CMM)](cmm.md)
 - [Output schemas](../getting-started/schemas.md#thmm-observed-state-panel)
 - API: [`gen_thmm`](../api/generators.md#gen_surv.thmm.gen_thmm)

--- a/docs/project/troubleshooting.md
+++ b/docs/project/troubleshooting.md
@@ -123,8 +123,10 @@ Work through these in order:
 ## Results changed after upgrading
 
 A bug fix in a sampler changes the numbers a given seed produces; 1.3.0 and
-2.0.0 both did this deliberately. Pin the version alongside the seed for
-anything that must reproduce. See
+2.0.0 both did this deliberately. 3.0.0 did it for `cmm` and `thmm`
+specifically, by rebuilding both on the
+[multistate engine](../models/multistate.md). Pin the version alongside the
+seed for anything that must reproduce. See
 [Reproducibility](../getting-started/reproducibility.md#what-stability-you-can-rely-on).
 
 ## Plots do not appear

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -63,6 +63,10 @@ NOT_EXECUTED: dict[str, list[str]] = {
     ],
     # Errors shown on purpose.
     "docs/models/index.md": ['generate(model="weibull")'],
+    # A deliberate type error, shown with the mypy output it produces rather
+    # than the ValidationError it would raise. Verified by hand against the
+    # published wheel.
+    "docs/getting-started/installation.md": ['gen_cphm(n="not an integer"'],
     "docs/guides/baselines.md": ["WeibullBaseline(shape=0.0"],
     # Uses `...` deliberately, to keep the point about generators short.
     "docs/getting-started/reproducibility.md": ["first  = generate(..., seed=rng)"],


### PR DESCRIPTION
The multistate engine got its own page at release, but nothing pointing at the package from outside was updated to know it exists.

`gen_multistate` appeared in exactly four files: its own page, `models/index.md`, and two API stubs. The **README — which is also the PyPI project page — did not mention it once**, and neither did the documentation landing page. The headline feature of a major release was invisible from both front doors.

The two illness-death pages were worse than silent. `cmm.md` and `thmm.md` still read as standalone implementations, with no link to the engine they are now configurations of and no mention that a given seed stops reproducing its 2.1.0 output. A reader arriving at `cmm.md` to find out why their numbers moved found nothing — the break was documented only in the CHANGELOG and the release notes.

## What changed

| Page | Gap |
|---|---|
| `README.md` | no engine section; no mention that `py.typed` ships |
| `docs/index.md` | model table stopped at the twelve `generate()` names |
| `docs/models/cmm.md`, `thmm.md` | no link to the engine, no seed-break notice |
| `docs/getting-started/reproducibility.md` | "already happened: 1.3.0 and 2.0.0" — stale as of the release |
| `docs/project/troubleshooting.md` | same stale list under *Results changed after upgrading* |
| `docs/getting-started/installation.md` | nothing documented the PEP 561 marker |
| `docs/models/index.md` | engine in the first table but not the diagram or the recovery table |

## Verification

The mypy output quoted in `installation.md` is verbatim from running mypy against the **published 3.0.0 wheel** in a clean virtualenv, not from the working tree.

That block is added to `NOT_EXECUTED` with a reason: it is a deliberate type error, so executing it raises the `ValidationError` rather than printing the type checker's verdict. `test_no_stale_exclusions` guards the entry against outliving its purpose.

The docs-example suite caught two mistakes in this change before it left my hands — the README block originally bound `df`, which the shared namespace carried into the sections below it and broke them. It binds `multistate` now.

- `mkdocs build --strict` — clean, no warnings
- `pytest tests/test_documentation_examples.py` — 46 passed

## Note on deployment

Pages only builds on `release: published`, so **this does not reach the live site on merge**. It describes 3.0.0 as shipped, so it is not ahead of PyPI — the workflow accepts a `workflow_dispatch` from `main` if you want it live before the next release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates documentation to cover the 3.0.0 release across the README and docs, including the new `gen_multistate` engine and the `py.typed` marker. Also documents that `cmm` and `thmm` seeds produce different output since 3.0.0.

- Adds an example of `gen_multistate` to the README and the models overview.
- Notes the seed-breaking change on the illness-death pages and reproducibility/troubleshooting pages.
- Adds a type-checking example to the installation page and marks it as not executed.

<sup>Written for commit b6dbc95dc9b138c872a6e0dbe429a1d811ca06a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

