### PR TITLE
ci: run the checks on develop, not only at the release boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
     name: Test with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
+      # One version failing should not cancel the others: knowing whether a
+      # failure is version-specific is most of the diagnosis. On the v3.0.0
+      # tag, 3.11 failed and took 3.12 and 3.13 down as cancelled, which hid
+      # that the cause had nothing to do with the version.
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
 
@@ -62,7 +67,12 @@ jobs:
       - name: Check runtime dependencies
         run: |
           poetry run python - <<'PY'
-          import importlib, sys
+          # `import importlib` does not bind the `util` submodule. This read
+          # worked only when something else had already imported it, which is
+          # why it passed on main and raised on the v3.0.0 tag from the very
+          # same commit.
+          import importlib.util
+          import sys
           missing = [m for m in ("pandas",) if importlib.util.find_spec(m) is None]
           if missing:
               print("Missing dependencies:", ", ".join(missing))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,21 @@ on:
   push:
     branches:
       - main
+      - develop
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
+      - develop
+
+# Adding `develop` doubles the trigger surface, so supersede rather than pile
+# up: a second push to a pull request cancels the first run. Only pull
+# requests are cancelled -- a run on `main`, `develop` or a tag is a record of
+# whether that commit was good and always finishes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,17 @@ name: Documentation Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
+
+# Adding `develop` doubles the trigger surface, so supersede rather than pile
+# up: a second push to a pull request cancels the first run. Only pull
+# requests are cancelled -- a run on `main`, `develop` or a tag is a record of
+# whether that commit was good and always finishes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   docs:


### PR DESCRIPTION
Both workflows were scoped to `main` alone, so **every pull request into `develop` reported no checks at all**:

```yaml
pull_request:
  branches: [main]
```

| PR | Target | Checks |
|---|---|---|
| #179 | `main` | 3.11 / 3.12 / 3.13, Code Quality, codecov |
| #173 | `develop` | none |
| #180 | `develop` | none — one third-party reviewer, which skipped |
| #182 | `develop` | none |

The release boundary itself was gated properly, so nothing broken could reach `main` silently. But that is the worst possible moment to learn a change is bad: a whole release of commits gets tested in one batch, after they are already on `develop` and interleaved with each other, which is exactly when attributing a failure is hardest. The engine coverage fix in #180 went in untested and was first checked days later.

`develop` is added to both the `push` and `pull_request` lists, so a change is verified when it is proposed and again on the merged state.

## Concurrency

Adding `develop` doubles the trigger surface, and neither workflow had a concurrency group — superseded runs ran to completion, so three pushes to a branch meant three full matrices.

Both get one that cancels **only** pull request runs:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

A run on `main`, `develop` or a tag is the record of whether that commit was good, so it always finishes.

## Not touched

`publish.yml` stays `workflow_dispatch`-only and `gh-pages.yml` stays on `release: published`. The documentation site still goes live only on a release and continues to match the PyPI version — that policy is unchanged.

This PR should be the first into `develop` to report checks, which is its own proof.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs CI and documentation checks on `develop` as well as `main` so pull requests into `develop` report checks, and fixes the runtime dependency check that failed on the v3.0.0 tag.

- Adds a concurrency group that cancels superseded pull request runs, while runs on `main`, `develop`, and tags always finish.
- Turns off `fail-fast` so one Python version failing doesn't cancel the others; the dependency check now imports `importlib.util` explicitly instead of depending on interpreter state.
- `publish.yml` and `gh-pages.yml` are unchanged; the docs site still publishes only on release.

<sup>Written for commit 9438cbe0d216d7e33e185d90ec639c9a8059860d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

