### PR TITLE
ci: key the concurrency group on the pull request, not the ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 # requests are cancelled -- a run on `main`, `develop` or a tag is a record of
 # whether that commit was good and always finishes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 # requests are cancelled -- a run on `main`, `develop` or a tag is a record of
 # whether that commit was good and always finishes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Two things, both small: the concurrency key is fixed, and this branch is cut from `main`, so merging it also carries the #184 merge commit back into `develop` and leaves the branches level.

## The cancellation

The group was `${{ github.workflow }}-${{ github.ref }}`, and a pull request run cancelled a branch run that should have been independent of it.

When #183 merged, the push run on `develop` started at 22:38:18. A pull_request run for the same branch started at 22:40:11, and fifteen seconds later all three of the push run's test jobs were cancelled **at the same instant** — while Code Quality, which had already finished, survived. That is a concurrency cancellation, not `fail-fast`, and it means the two runs shared a group.

They should not have. `cancel-in-progress` is deliberately false for a push, so a run on a branch is meant to finish and stand as the record of whether that commit was good. Instead `develop` was left showing a cancelled CI run and had to be re-run by hand to show it was green — which it was, on all three versions.

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

Keying on the pull request number when there is one, and the ref otherwise, makes the two kinds of run structurally incapable of sharing a group, whatever `github.ref` resolves to for a given event. That is the standard form and it does not depend on my being right about the mechanism.

## Note

This PR should report its own checks, since `develop` now carries the trigger fix from #183. #183 could not — GitHub registers `pull_request` triggers from the base branch, so the fix only took effect for the PR after it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrency group keying in `ci.yml` and `docs.yml` so pull request runs no longer cancel push runs on the same branch. The group was keyed on `github.ref`, which made a PR run and a push run share a group; the new key uses the pull request number when one exists and the ref otherwise. Merging this also brings a merge commit from `main` into `develop`.

<sup>Written for commit a199c5bec110e7e7403117a6cb5501b860631ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

