### PR TITLE
chore: bump the black pre-commit hook to match the dev group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # and mypy 1.20.
 repos:
   - repo: https://github.com/psf/black
-    rev: 25.12.0
+    rev: 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
#173 moved the dev group to black 26.3.1, but the hook stayed pinned to the version the advisory names:

```yaml
- repo: https://github.com/psf/black
  rev: 25.12.0
```

`pre-commit` builds each hook in its own isolated environment from that `rev`, **not** from the project's lock file. So `Code Quality` in CI — which runs `pre-commit run --all-files` — was still executing black 25.12.0, while `poetry run black` used 26.3.1.

Merging the dependency bump on its own therefore left the vulnerable version running in the one place black is actually invoked on every commit. That is the gap this closes.

The two could also have disagreed about formatting across a major version, which is why the revs are deliberately kept equal to the locked versions. They all match again:

| Hook | rev | locked |
|---|---|---|
| black | 26.3.1 | 26.3.1 |
| isort | 7.0.0 | 7.0.0 |
| flake8 | 6.1.0 | 6.1.0 |
| mypy | v1.20.2 | 1.20.2 |

`pre-commit run --all-files` passes every hook against the whole tree with **no reformatting**, so the major bump needs no code change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the `black` pre-commit hook with the dev group by bumping `rev` from 25.12.0 to 26.3.1. Previously the hook stayed on the advisory-named version while `poetry run black` used 26.3.1, so CI was still executing the vulnerable `black` on every commit. No code changes are needed—`pre-commit run --all-files` passes with no reformatting across any hook.

<sup>Written for commit c93ce5868d1aa02d25e90eece9bad73a0ab00659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

