### PR TITLE
test: property-based invariants for every generator, and two tdcm defects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # CHANGELOG
 
+## Unreleased
+
+Property-based tests across all twelve generators, and the two `tdcm` defects
+they found.
+
+### Behaviour changes
+
+- **`gen_tdcm` raises when `exp(beta[0] * z)` leaves the range of a float**
+  instead of returning a frame. A Weibull `dist_par` shape below 1 is an
+  exponent above 1 in `(-log(1 - u) / a) ** (1 / b)`, so the covariate reached
+  the tens of thousands and the linear predictor overflowed. `t = log_term /
+  inf` is exactly 0.0, and `status = (t <= c)` then reported an **observed
+  event at time zero** for every subject, in a zero-length risk interval; with
+  the sign of `beta[0]` flipped it underflowed instead and every subject came
+  back censored. Both frames had the right columns, the right dtypes and no
+  NaN. No correct call changes behaviour — the affected parameter combinations
+  never produced usable data.
+- **`gen_tdcm` rejects `corr` at the endpoints.** `validate_gen_tdcm_inputs`
+  allowed `(0, 1]` for Weibull and `[-1, 1]` for exponential, and the
+  documentation promised the same, but the Gaussian copula underneath needs
+  strict inequalities: its covariance `[[1, corr], [corr, 1]]` is singular at
+  `|corr| = 1`. Those values already failed — deeper in, reporting a different
+  range from a helper the caller never named. They now fail at the model's own
+  boundary, quoting the range it actually enforces.
+
+### Tests
+
+- **`tests/test_properties.py`** drives every generator from Hypothesis:
+  output invariants (the column contract, no NaN or infinity, `status` within
+  its declared set, no zero-length risk intervals, no event at time zero), the
+  seed contract (the same seed gives the same frame, and an `int` agrees with
+  the generator it seeds), and rejection of out-of-domain values. A test fails
+  if a model is registered without a strategy.
+
+### Documentation
+
+- The `corr` range on the TDCM page and in the `gen_tdcm` docstring now match
+  what is enforced.
+
 ## v3.0.0 (2026-08-25)
 
 A general multistate engine, with the two illness-death models rebuilt on top of

--- a/TODO.md
+++ b/TODO.md
@@ -52,9 +52,32 @@ items here are about finding the ones that have not been.
 - [ ] **R parity fixtures.** Frozen reference outputs from the R `genSurv`
       package for the models ported from it, so divergence is detected rather
       than argued about. Column names differ by design, so parity is on values.
-- [ ] **Wider property-based testing.** Hypothesis is already used in a few
-      places; extend it to parameter validation and invariants across all
-      generators. Complements the statistical tests rather than replacing them.
+- [x] **Wider property-based testing.** `tests/test_properties.py` drives all
+      twelve generators from Hypothesis: output invariants (the column
+      contract, no NaN or infinity, `status` within its declared set, no
+      zero-length risk intervals, no event at time zero), the seed contract
+      (the same seed gives the same frame, and an `int` agrees with the
+      generator it seeds), and rejection of out-of-domain values. A test fails
+      if a model is registered without a strategy, so none can escape it.
+
+      It found two defects on its way in, both in `tdcm`.
+
+      `validate_gen_tdcm_inputs` allowed `corr` at the endpoints — `(0, 1]` for
+      Weibull and `[-1, 1]` for exponential, which the documentation promised
+      too — while the Gaussian copula underneath requires strict inequalities,
+      its covariance `[[1, corr], [corr, 1]]` being singular at `|corr| = 1`.
+      The endpoints passed the model's own check, failed deeper in, and quoted
+      a different range from a helper the caller never named.
+
+      The second was worse. A Weibull `dist_par` shape below 1 is an exponent
+      above 1 in `(-log(1 - u) / a) ** (1 / b)`, so the covariate reached the
+      tens of thousands and `exp(beta[0] * z)` left the range of a float. Then
+      `t = log_term / inf` is exactly 0.0 and `status = (t <= c)` reported an
+      **observed event at time zero** for every subject, in a zero-length risk
+      interval; with the sign of `beta[0]` flipped it underflowed instead and
+      every subject came back censored. Both frames had the right columns, the
+      right dtypes and no NaN, so a finiteness check passed them. `gen_tdcm`
+      now raises, naming the largest covariate drawn and what to change.
 - [x] **Centralised parameter validation.** Finiteness is now checked where
       positivity is. The inconsistency had a single cause: every comparison
       with NaN is false, so `value <= 0` admitted it, and `inf > 0` is true.
@@ -73,9 +96,9 @@ items here are about finding the ones that have not been.
       All rejected now, with `tests/test_input_hardening.py` walking every
       numeric argument of every model to keep it that way.
 - [ ] **Return the maturity classifier to `5 - Production/Stable`** once the
-      items above are in place. Distribution tests have now shipped for all
-      twelve generators, which was the stated blocker; R parity fixtures and
-      wider property-based testing remain. Worth waiting for those: the
+      items above are in place. Distribution tests and property-based tests
+      have now shipped for all twelve generators; **R parity fixtures are the
+      last blocker**. Worth waiting for those: the
       distribution work found two more defects on its way in, which is not yet
       the profile of a package claiming stability.
 
@@ -139,12 +162,17 @@ Small, concrete, and each one has already cost time:
       `ci.yml` now runs `poetry check --lock`, so a `pyproject.toml` edit
       without a matching relock fails immediately instead of resolving
       differently in silence.
-- [ ] **Fix the `develop`/`main` divergence.** Squash-merging `develop -> main`
-      leaves the squash commit outside `develop`'s history, so every subsequent
-      release pull request conflicts. A conflicting pull request gets **no CI run
-      at all** rather than a failing one, which reads as "still queued" and is
-      easy to misdiagnose. Either use merge commits for release PRs, or reset
-      `develop` to `main` after each release.
+- [x] **Fixed the `develop`/`main` divergence.** Release pull requests use
+      merge commits now, and `main` is merged back into `develop` immediately
+      after each one, so the branches stay level and no release PR replays an
+      earlier merge as a phantom diff.
+
+      A second cause of "no CI run at all" turned out to be unrelated and
+      worse: both workflows were scoped to `main`, so **every** pull request
+      into `develop` reported no checks, conflicting or not. Tests only ran at
+      the release boundary, batched, after the commits were already in. Both
+      now run on `develop` as well, and the concurrency group is keyed on the
+      pull request number so a PR run cannot cancel a branch run.
 - [x] **Removed the vestigial `[tool.semantic_release]` configuration**, which no
       workflow read, along with the `python-semantic-release` development
       dependency that existed only to serve it.
@@ -267,8 +295,11 @@ of generators" to "a tool for evaluating survival methodology".
 
 ## Performance
 
-- [ ] **Vectorise the remaining subject-level loops.** `gen_thmm` still loops per
-      subject. This is where the available speedup actually is.
+- [ ] **Vectorise the remaining subject-level loops.** `gen_thmm` no longer
+      does — the multistate engine removed that loop, with the measurements in
+      the architecture section above. `cphm`, `piecewise_exponential`,
+      `mixture_cure`, both competing-risks models and `recurrent_events` still
+      draw one subject at a time, and that is where the remaining speedup is.
 - [ ] **Benchmark before optimising further.** The benchmark suite exists; use it
       to justify any change rather than assuming one is needed.
 - [ ] **Parallel generation via `SeedSequence.spawn()`**, which gives reproducible

--- a/docs/models/tdcm.md
+++ b/docs/models/tdcm.md
@@ -36,7 +36,7 @@ gen_tdcm(n, dist, corr, dist_par, model_cens, cens_par, beta, lam, seed=None)
 |---|---|---|---|
 | `n` | `int` | > 0 | number of subjects |
 | `dist` | `str` | `"weibull"` or `"exponential"` | marginals of the bivariate covariate draw |
-| `corr` | `float` | `(0, 1]` for Weibull, `[-1, 1]` for exponential | dependence between baseline covariate and crossover time |
+| `corr` | `float` | `(0, 1)` for Weibull, `(-1, 1)` for exponential | dependence between baseline covariate and crossover time |
 | `dist_par` | `Sequence[float]` | **4** for Weibull, **2** for exponential; all > 0 | parameters of those marginals |
 | `model_cens` | `str` | `"uniform"` or `"exponential"` | censoring mechanism |
 | `cens_par` | `float` | > 0 | censoring parameter |

--- a/gen_surv/tdcm.py
+++ b/gen_surv/tdcm.py
@@ -8,7 +8,7 @@ from gen_surv._rng import RandomStateLike, resolve_rng
 from gen_surv._truth import record
 from gen_surv.bivariate import sample_bivariate_distribution
 from gen_surv.censoring import CensoringFunc, rexpocens, runifcens
-from gen_surv.validation import validate_gen_tdcm_inputs
+from gen_surv.validation import ParameterError, validate_gen_tdcm_inputs
 
 
 def generate_censored_observations(
@@ -52,12 +52,36 @@ def generate_censored_observations(
     rng = resolve_rng(seed)
 
     z1 = b[:, 1]
-    x = lam * b[:, 0] * np.exp(beta[0] * z1)
+
+    # A heavy-tailed covariate distribution -- a Weibull `dist_par` shape well
+    # below 1 -- puts `z1` in the tens of thousands, and `exp(beta[0] * z1)`
+    # then leaves the range of a float. Neither outcome is survivable:
+    # overflow to `inf` makes `t1 = log_term / inf` exactly 0.0, which
+    # `status = (t <= c)` reports as an *observed event at time zero* in a
+    # zero-length risk interval; underflow to 0.0 makes `t` infinite, silently
+    # reported as censored. Both are frames of the right shape carrying data no
+    # analysis should be handed, so this raises rather than returning one.
+    # Errors are suppressed only because the result is inspected immediately
+    # below and turned into a message that says what to change; NumPy's warning
+    # names the expression, not the parameter behind it.
+    with np.errstate(over="ignore", under="ignore"):
+        exp_b0_z1 = np.exp(beta[0] * z1)
+    if not np.all(np.isfinite(exp_b0_z1)) or np.any(exp_b0_z1 == 0.0):
+        extreme = float(z1[np.argmax(np.abs(beta[0] * z1))])
+        raise ParameterError(
+            "beta",
+            beta,
+            f"combined with the covariate distribution, exp(beta[0] * z) left "
+            f"the range of a float (largest covariate drawn: {extreme:.3g}). "
+            f"Reduce beta[0], or widen the Weibull shape in dist_par -- a "
+            f"shape below 1 is heavy-tailed and draws very large covariates",
+        )
+
+    x = lam * b[:, 0] * exp_b0_z1
     u = rng.uniform(size=n)
     c = rfunc(n, cens_par, rng)
 
     threshold = 1 - np.exp(-x)
-    exp_b0_z1 = np.exp(beta[0] * z1)
     log_term = -np.log(1 - u)
 
     # Before the crossover the hazard is lam * exp(beta[0] * z1); after it, that
@@ -122,7 +146,10 @@ def gen_tdcm(
     dist : {"weibull", "exponential"}
         Type of marginal distributions.
     corr : float
-        Correlation coefficient between covariates.
+        Correlation between the baseline covariate and the crossover time, on
+        the latent normal scale. Must be in ``(0, 1)`` for ``dist='weibull'``
+        and ``(-1, 1)`` for ``dist='exponential'``; the endpoints make the
+        copula's covariance singular.
     dist_par : Sequence[float]
         Distribution parameters.
     model_cens : {"uniform", "exponential"}

--- a/gen_surv/validation.py
+++ b/gen_surv/validation.py
@@ -413,16 +413,21 @@ def validate_gen_tdcm_inputs(
     _validate_base(n, model_cens, cens_par)
     ensure_in_choices(dist, "dist", {"weibull", "exponential"})
 
+    # The endpoints are excluded because the Gaussian copula underneath cannot
+    # take them: its covariance is [[1, corr], [corr, 1]], singular at
+    # |corr| = 1. This validator used to allow them and the call failed later
+    # inside `validate_dg_biv_inputs`, reporting a different range than the one
+    # checked here.
     if dist == "weibull":
-        if not (0 < corr <= 1):
-            raise ParameterError("corr", corr, "with dist='weibull' must be in (0,1]")
+        if not (0 < corr < 1):
+            raise ParameterError("corr", corr, "with dist='weibull' must be in (0,1)")
         ensure_sequence_length(dist_par, _WEIBULL_DIST_PAR_LEN, "dist_par")
         ensure_positive_sequence(dist_par, "dist_par")
 
     if dist == "exponential":
-        if not (-1 <= corr <= 1):
+        if not (-1 < corr < 1):
             raise ParameterError(
-                "corr", corr, "with dist='exponential' must be in [-1,1]"
+                "corr", corr, "with dist='exponential' must be in (-1,1)"
             )
         ensure_sequence_length(dist_par, _EXP_DIST_PAR_LEN, "dist_par")
         ensure_positive_sequence(dist_par, "dist_par")

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,526 @@
+"""Invariants that must hold for every generator, over parameters Hypothesis picks.
+
+``test_distributions.py`` asks whether one model's sampled times follow the
+distribution it declares. These tests ask a weaker question of all twelve at
+once: whatever the parameters, is the frame that comes back well formed, and
+does the same seed still give the same data?
+
+A weaker question asked over a wider surface finds a different class of defect.
+The fixed-parameter suites exercise one point per model. These walk a range, so
+a bug that only shows at a small ``n``, a large hazard, a coefficient near zero
+or a censoring distribution that swallows every event has somewhere to appear.
+
+Three families here:
+
+- **Output invariants.** The column contract, no NaN or infinity, ``status`` in
+  ``{0, 1}``, times non-negative, intervals never inverted, states within the
+  declared set.
+- **The seed contract.** Documented on the reproducibility page: the same seed
+  gives the same frame, and an ``int`` agrees with the generator it seeds. Both
+  are promises to users, and neither was tested across all twelve models.
+- **Rejection.** A value outside a parameter's domain must raise
+  ``ValidationError``, naming the argument -- never return a frame, and never
+  surface as a NumPy error about something the caller did not pass.
+
+``test_input_hardening.py`` covers NaN and infinity exhaustively at fixed
+points; this covers the ordinary out-of-domain values over a range.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from gen_surv import generate
+from gen_surv.interface import _model_map
+from gen_surv.validation import ValidationError
+from tests.test_generate_regression import EXPECTED_COLUMNS
+
+# Keep every example small and quick: these tests are about the shape of the
+# contract, not statistical power, and Hypothesis runs each one many times.
+SETTINGS = settings(
+    max_examples=25,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+
+N = st.integers(min_value=2, max_value=25)
+SEED = st.integers(min_value=0, max_value=10_000)
+CENS = st.sampled_from(["uniform", "exponential"])
+POSITIVE = st.floats(
+    min_value=0.05, max_value=4.0, allow_nan=False, allow_infinity=False
+)
+COEF = st.floats(min_value=-1.5, max_value=1.5, allow_nan=False, allow_infinity=False)
+FRACTION = st.floats(
+    min_value=0.05, max_value=0.95, allow_nan=False, allow_infinity=False
+)
+
+
+def _coefs(size: int) -> st.SearchStrategy[list]:
+    return st.lists(COEF, min_size=size, max_size=size)
+
+
+def _positives(size: int) -> st.SearchStrategy[list]:
+    return st.lists(POSITIVE, min_size=size, max_size=size)
+
+
+#: `dist_par` for `tdcm` is drawn from a narrower band than POSITIVE. The
+#: bivariate sampler builds each margin as `(-log(1 - u) / a) ** (1 / b)`, so a
+#: `b` well below 1 is an exponent well above 1 and the covariate reaches the
+#: tens of thousands. `exp(beta[0] * z)` then leaves the range of a float,
+#: which `gen_tdcm` now refuses -- see
+#: `test_tdcm_raises_rather_than_emitting_zero_time_events` for what it used to
+#: return instead. Excluded here so the invariant tests stay on parameters that
+#: are meant to produce a frame; the excluded region has its own test.
+MODERATE = st.floats(
+    min_value=0.5, max_value=4.0, allow_nan=False, allow_infinity=False
+)
+
+
+@st.composite
+def _tdcm_kwargs(draw: st.DrawFn) -> Dict[str, Any]:
+    """``dist`` constrains both ``corr`` and the length of ``dist_par``."""
+    dist = draw(st.sampled_from(["weibull", "exponential"]))
+    if dist == "weibull":
+        corr = draw(
+            st.floats(
+                min_value=0.01,
+                max_value=1.0,
+                exclude_max=True,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        dist_par = draw(st.lists(MODERATE, min_size=4, max_size=4))
+    else:
+        corr = draw(
+            st.floats(
+                min_value=-1.0,
+                max_value=1.0,
+                exclude_min=True,
+                exclude_max=True,
+                allow_nan=False,
+                allow_infinity=False,
+            )
+        )
+        dist_par = draw(st.lists(MODERATE, min_size=2, max_size=2))
+    return {
+        "n": draw(N),
+        "dist": dist,
+        "corr": corr,
+        "dist_par": dist_par,
+        "model_cens": draw(CENS),
+        "cens_par": draw(POSITIVE),
+        "beta": draw(_coefs(2)),
+        "lam": draw(POSITIVE),
+    }
+
+
+MODEL_STRATEGIES: Dict[str, st.SearchStrategy[Dict[str, Any]]] = {
+    "cphm": st.fixed_dictionaries(
+        {
+            "n": N,
+            "beta": COEF,
+            "covariate_range": POSITIVE,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+        }
+    ),
+    "aft_ln": st.fixed_dictionaries(
+        {
+            "n": N,
+            "beta": _coefs(1),
+            "sigma": POSITIVE,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+        }
+    ),
+    "aft_weibull": st.fixed_dictionaries(
+        {
+            "n": N,
+            "beta": _coefs(1),
+            "shape": POSITIVE,
+            "scale": POSITIVE,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+        }
+    ),
+    "aft_log_logistic": st.fixed_dictionaries(
+        {
+            "n": N,
+            "beta": _coefs(1),
+            "shape": POSITIVE,
+            "scale": POSITIVE,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+        }
+    ),
+    "piecewise_exponential": st.fixed_dictionaries(
+        {
+            "n": N,
+            "breakpoints": _positives(1),
+            "hazard_rates": _positives(2),
+            "betas": _coefs(2),
+        }
+    ),
+    "competing_risks": st.fixed_dictionaries(
+        {
+            "n": N,
+            "n_risks": st.just(2),
+            "baseline_hazards": _positives(2),
+            "betas": st.lists(_coefs(2), min_size=2, max_size=2),
+        }
+    ),
+    "competing_risks_weibull": st.fixed_dictionaries(
+        {
+            "n": N,
+            "n_risks": st.just(2),
+            "shape_params": _positives(2),
+            "scale_params": _positives(2),
+        }
+    ),
+    "mixture_cure": st.fixed_dictionaries(
+        {
+            "n": N,
+            "cure_fraction": FRACTION,
+            "baseline_hazard": POSITIVE,
+            "betas_survival": _coefs(2),
+            "betas_cure": _coefs(2),
+        }
+    ),
+    "cmm": st.fixed_dictionaries(
+        {
+            "n": N,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+            "beta": _coefs(3),
+            "covariate_range": POSITIVE,
+            "rate": _positives(6),
+        }
+    ),
+    "thmm": st.fixed_dictionaries(
+        {
+            "n": N,
+            "model_cens": CENS,
+            "cens_par": POSITIVE,
+            "beta": _coefs(3),
+            "covariate_range": POSITIVE,
+            "rate": _positives(3),
+        }
+    ),
+    "tdcm": _tdcm_kwargs(),
+    "recurrent_events": st.fixed_dictionaries(
+        {
+            "n": N,
+            "baseline_params": st.fixed_dictionaries({"rate": POSITIVE}),
+            "betas": _coefs(2),
+            "followup_time": POSITIVE,
+            "cens_par": POSITIVE,
+        }
+    ),
+}
+
+#: Models returning exactly one row per subject. The rest return a variable
+#: number, so only the subject count can be checked.
+ONE_ROW_PER_SUBJECT = {
+    "cphm",
+    "aft_ln",
+    "aft_weibull",
+    "aft_log_logistic",
+    "piecewise_exponential",
+    "competing_risks",
+    "competing_risks_weibull",
+    "mixture_cure",
+    "tdcm",
+}
+
+#: Frames laid out as counting-process risk intervals.
+INTERVAL_LAYOUT = {"cmm", "tdcm", "recurrent_events"}
+
+
+def test_every_registered_model_has_a_strategy() -> None:
+    """A model added without a strategy would silently escape all of this."""
+    assert set(MODEL_STRATEGIES) == set(_model_map)
+
+
+def _assert_invariants(model: str, df: pd.DataFrame, kwargs: Dict[str, Any]) -> None:
+    n = kwargs["n"]
+
+    assert list(df.columns) == EXPECTED_COLUMNS[model], f"{model} broke its columns"
+    assert len(df) > 0, f"{model} returned an empty frame"
+
+    numeric = df.select_dtypes(include=[np.number])
+    assert np.isfinite(numeric.to_numpy()).all(), f"{model} produced NaN or infinity"
+
+    if "status" in df.columns:
+        # Competing risks put the winning cause in `status`, not an indicator:
+        # 0 is censored and 1..n_risks name the cause. Every other model is
+        # binary.
+        allowed = set(range(kwargs.get("n_risks", 1) + 1))
+        assert (
+            set(df["status"].unique()) <= allowed
+        ), f"{model} has a status outside {sorted(allowed)}"
+
+    for column in ("time", "start", "stop"):
+        if column in df.columns:
+            assert (df[column] >= 0).all(), f"{model} has a negative {column}"
+
+    if model in INTERVAL_LAYOUT:
+        # Strictly greater, not `>=`. A zero-length risk interval contributes
+        # no exposure and cannot carry an event, so it is never a legitimate
+        # row -- and `>=` is exactly what let the `tdcm` overflow through:
+        # `exp(beta[0] * z)` reaching `inf` collapsed every time to 0.0 and
+        # `status = (t <= c)` then called it an observed event at time zero.
+        # See `test_tdcm_raises_rather_than_emitting_zero_time_events`.
+        assert (
+            df["stop"] > df["start"]
+        ).all(), f"{model} produced a zero-length or inverted interval"
+
+    if model in ONE_ROW_PER_SUBJECT and "time" in df.columns:
+        assert (df["time"] > 0).all(), f"{model} produced an event at time zero"
+
+    if model in ONE_ROW_PER_SUBJECT:
+        assert len(df) == n, f"{model} returned {len(df)} rows for n={n}"
+
+    if "id" in df.columns:
+        assert df["id"].nunique() <= n, f"{model} invented subjects"
+
+    if model == "thmm":
+        assert set(df["state"].unique()) <= {1, 2, 3}
+    if model == "cmm":
+        assert set(df["from_state"].unique()) <= {1, 2}
+        assert set(df["to_state"].unique()) <= {2, 3}
+    if model == "recurrent_events":
+        assert (df["enum"] >= 1).all()
+    if model == "mixture_cure":
+        assert set(df["cured"].unique()) <= {0, 1}
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_STRATEGIES))
+def test_output_invariants_hold_for_any_valid_parameters(model: str) -> None:
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(kwargs=strategy, seed=SEED)
+    def check(kwargs: Dict[str, Any], seed: int) -> None:
+        df = generate(model=model, **kwargs, seed=seed)
+        _assert_invariants(model, df, kwargs)
+
+    check()
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_STRATEGIES))
+def test_the_same_seed_gives_the_same_frame(model: str) -> None:
+    """The first row of the reproducibility contract, for all twelve models."""
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(kwargs=strategy, seed=SEED)
+    def check(kwargs: Dict[str, Any], seed: int) -> None:
+        first = generate(model=model, **kwargs, seed=seed)
+        second = generate(model=model, **kwargs, seed=seed)
+        pd.testing.assert_frame_equal(first, second)
+
+    check()
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_STRATEGIES))
+def test_an_integer_seed_agrees_with_the_generator_it_seeds(model: str) -> None:
+    """``seed=7`` and ``seed=default_rng(7)`` are documented as equivalent.
+
+    ``resolve_rng`` passes an ``int`` to ``default_rng`` and returns a
+    ``Generator`` unchanged, so the two must draw the same stream. Users rely
+    on this to share one generator across several simulators.
+    """
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(kwargs=strategy, seed=SEED)
+    def check(kwargs: Dict[str, Any], seed: int) -> None:
+        from_int = generate(model=model, **kwargs, seed=seed)
+        from_generator = generate(
+            model=model, **kwargs, seed=np.random.default_rng(seed)
+        )
+        pd.testing.assert_frame_equal(from_int, from_generator)
+
+    check()
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_STRATEGIES))
+def test_a_non_positive_n_is_always_rejected(model: str) -> None:
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(kwargs=strategy, bad_n=st.integers(min_value=-50, max_value=0))
+    def check(kwargs: Dict[str, Any], bad_n: int) -> None:
+        with pytest.raises(ValidationError):
+            generate(model=model, **{**kwargs, "n": bad_n}, seed=1)
+
+    check()
+
+
+@pytest.mark.parametrize("model", sorted(MODEL_STRATEGIES))
+def test_an_unknown_censoring_model_is_always_rejected(model: str) -> None:
+    """Only the models that expose ``model_cens``; the rest have no such knob."""
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(kwargs=strategy, name=st.text(min_size=1, max_size=8))
+    def check(kwargs: Dict[str, Any], name: str) -> None:
+        if "model_cens" not in kwargs or name in {"uniform", "exponential"}:
+            return
+        with pytest.raises(ValidationError):
+            generate(model=model, **{**kwargs, "model_cens": name}, seed=1)
+
+    check()
+
+
+@pytest.mark.parametrize(
+    "model,argument",
+    [
+        ("cphm", "covariate_range"),
+        ("cphm", "cens_par"),
+        ("aft_ln", "sigma"),
+        ("aft_weibull", "shape"),
+        ("aft_weibull", "scale"),
+        ("aft_log_logistic", "shape"),
+        ("aft_log_logistic", "scale"),
+        ("mixture_cure", "baseline_hazard"),
+        ("cmm", "covariate_range"),
+        ("thmm", "covariate_range"),
+        ("tdcm", "lam"),
+        ("recurrent_events", "followup_time"),
+    ],
+)
+def test_a_non_positive_value_is_rejected_where_positivity_is_required(
+    model: str, argument: str
+) -> None:
+    strategy = MODEL_STRATEGIES[model]
+
+    @SETTINGS
+    @given(
+        kwargs=strategy,
+        bad=st.floats(
+            min_value=-20.0, max_value=0.0, allow_nan=False, allow_infinity=False
+        ),
+    )
+    def check(kwargs: Dict[str, Any], bad: float) -> None:
+        with pytest.raises(ValidationError):
+            generate(model=model, **{**kwargs, argument: bad}, seed=1)
+
+    check()
+
+
+# --------------------------------------------------------------------------
+# Regressions found by the properties above
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dist,corr,n_par",
+    [
+        ("weibull", 1.0, 4),
+        ("exponential", 1.0, 2),
+        ("exponential", -1.0, 2),
+    ],
+)
+def test_tdcm_rejects_the_correlation_endpoints_at_its_own_boundary(
+    dist: str, corr: float, n_par: int
+) -> None:
+    """Two validators disagreed about ``corr``, and the wider one ran first.
+
+    ``validate_gen_tdcm_inputs`` allowed ``0 < corr <= 1`` for Weibull and
+    ``-1 <= corr <= 1`` for exponential. The Gaussian copula underneath needs
+    strict inequalities -- its covariance is ``[[1, corr], [corr, 1]]``, which
+    is singular at ``|corr| = 1`` -- and ``validate_dg_biv_inputs`` enforced
+    that. So the endpoints passed the model's own check, failed deeper in, and
+    reported "must be a numeric value between -1 and 1": a different range from
+    the one the model advertised, from a helper the caller never named. The
+    documented range said `(0, 1]` and `[-1, 1]` too.
+
+    The error must now come from the model's boundary and quote the real range.
+    """
+    with pytest.raises(ValidationError, match="corr"):
+        generate(
+            model="tdcm",
+            n=5,
+            dist=dist,
+            corr=corr,
+            dist_par=[1.0] * n_par,
+            model_cens="uniform",
+            cens_par=1.0,
+            beta=[0.5, 0.3],
+            lam=1.0,
+            seed=1,
+        )
+
+
+@pytest.mark.parametrize(
+    "dist,corr,n_par", [("weibull", 0.99, 4), ("exponential", -0.99, 2)]
+)
+def test_tdcm_still_accepts_values_just_inside_the_boundary(
+    dist: str, corr: float, n_par: int
+) -> None:
+    """Tightening the bound must not have moved it past what already worked."""
+    df = generate(
+        model="tdcm",
+        n=20,
+        dist=dist,
+        corr=corr,
+        dist_par=[1.0] * n_par,
+        model_cens="uniform",
+        cens_par=1.0,
+        beta=[0.5, 0.3],
+        lam=1.0,
+        seed=1,
+    )
+    assert len(df) == 20
+
+
+def test_tdcm_raises_rather_than_emitting_zero_time_events() -> None:
+    """``exp(beta[0] * z)`` leaving float range used to produce a valid-looking frame.
+
+    The covariate is the second margin of the bivariate draw, built as
+    ``(-log(1 - u) / a) ** (1 / b)``. A ``b`` well below 1 is an exponent well
+    above 1, so the covariate reaches the tens of thousands and
+    ``exp(beta[0] * z)`` overflows.
+
+    What came back was not an error. ``t1 = log_term / inf`` is exactly 0.0, and
+    ``status = (t <= c)`` then reported an **observed event at time zero** for
+    every subject, in a zero-length risk interval. With the sign of ``beta[0]``
+    flipped the same expression underflowed to 0.0, making ``t`` infinite and
+    every subject censored. Both frames had the right columns, the right dtypes
+    and no NaN, so a finiteness check passed them.
+    """
+    with pytest.raises(ValidationError, match="exp"):
+        generate(
+            model="tdcm",
+            n=2,
+            dist="weibull",
+            corr=0.5,
+            dist_par=[1.0, 1.0, 0.125, 0.125],
+            model_cens="uniform",
+            cens_par=1.0,
+            beta=[1.0, 0.0],
+            lam=1.0,
+            seed=0,
+        )
+
+    with pytest.raises(ValidationError, match="exp"):
+        generate(
+            model="tdcm",
+            n=2,
+            dist="weibull",
+            corr=0.5,
+            dist_par=[1.0, 1.0, 0.125, 0.125],
+            model_cens="uniform",
+            cens_par=1.0,
+            beta=[-1.0, 0.0],
+            lam=1.0,
+            seed=0,
+        )


### PR DESCRIPTION
The second of the two blockers on returning the maturity classifier to `5 - Production/Stable`. R parity fixtures are now the last one.

`tests/test_properties.py` drives all twelve generators from Hypothesis rather than from one fixed parameter set each:

- **Output invariants** — the column contract, no NaN or infinity, `status` within its declared set, times non-negative, no zero-length risk intervals, no event at time zero, states within the declared graph.
- **The seed contract** — the same seed gives the same frame, and an `int` agrees with the generator it seeds. Both are promised on the reproducibility page; neither was tested across all twelve models.
- **Rejection** — out-of-domain values raise `ValidationError` naming the argument, rather than returning a frame or surfacing as a NumPy error about something the caller never passed.

`test_every_registered_model_has_a_strategy` fails if a model is registered without one, so a new generator cannot quietly escape any of it.

## What it found

Two defects, both in `tdcm`.

### `corr` was accepted at endpoints that never worked

`validate_gen_tdcm_inputs` allowed `(0, 1]` for Weibull and `[-1, 1]` for exponential. The page and the docstring promised the same. But the Gaussian copula underneath needs strict inequalities — its covariance `[[1, corr], [corr, 1]]` is singular at `|corr| = 1` — and `validate_dg_biv_inputs` enforced that.

So the endpoints passed the model's own check, failed deeper in, and reported *"must be a numeric value between -1 and 1"*: a different range from the one the model advertised, raised by a helper the caller never named. They now fail at the model's own boundary, quoting the range actually enforced.

### An overflow that produced a valid-looking frame

This one is the reason the invariants were worth writing.

`dist_par` builds each margin as `(-log(1 - u) / a) ** (1 / b)`, so a `b` below 1 is an exponent above 1 and the covariate reaches the tens of thousands. `exp(beta[0] * z)` then leaves the range of a float:

| | result | reported as |
|---|---|---|
| overflow to `inf` | `t = log_term / inf` is exactly `0.0` | **an observed event at time zero**, `status = 1` |
| underflow to `0` | `t` is infinite | censored, `status = 0` |

```
 id  start  stop  status     covariate  tdcov
1.0    0.0   0.0     1.0 169613.661041    0.0
2.0    0.0   0.0     1.0   5623.501137    0.0
```

Right columns, right dtypes, no NaN — a finiteness check passes it. `gen_tdcm` now raises, naming the largest covariate drawn and what to change.

**The invariant that missed it has been tightened.** Risk intervals must satisfy `stop > start`, not `stop >= start`; a zero-length interval carries no exposure and cannot hold an event, and `>=` is precisely what let this through. One-row-per-subject models may not report an event at time zero either.

## Scope

No correct call changes behaviour. The affected parameter combinations never produced usable data — they returned garbage or failed with a confusing message. **The frozen regression baselines are unchanged**, which is the evidence that ordinary calls did not move.

692 tests pass, up from 613.

Worth your call on versioning: this rejects inputs that previously returned a frame, which is the same shape as the NaN hardening that landed in 3.0.0 as a breaking change. I would call it a minor, since nothing that worked stops working — but it is your release policy.

## Roadmap corrections made while here

- **Performance** claimed `gen_thmm` still loops per subject; the engine removed that loop in 3.0.0. The item stays open, correctly naming `cphm`, `piecewise_exponential`, `mixture_cure`, both competing-risks models and `recurrent_events`, which do still loop.
- The **`develop`/`main` divergence** item is closed, and now records the unrelated and larger cause of "no CI run at all" found alongside it: both workflows were scoped to `main`, so every PR into `develop` reported no checks.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds property-based tests that drive all twelve generators through Hypothesis, and fixes two `tdcm` defects they uncovered.

**Bug Fixes**

- `gen_tdcm` now rejects `corr` at the endpoints, which the copula underneath can't take; these previously failed deeper in with a confusing message about a different range.
- `gen_tdcm` now raises when `exp(beta[0] * z)` leaves float range, instead of returning frames that reported events at time zero or censored every subject.

**Tests**

- `tests/test_properties.py` checks output invariants, the seed reproducibility contract, and rejection of out-of-domain values across all twelve generators.
- Risk intervals must now satisfy `stop > start`; the previous `>=` admitted the zero-length intervals the overflow produced.
- A test fails if a model is registered without a strategy, so new generators can't quietly escape the suite.

No correct call changes behavior. Frozen regression baselines are unchanged; 692 tests pass, up from 613.

<sup>Written for commit e558481d1dc7518f3e0cbd681734ee9e7e4cb030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

