### PR TITLE
chore: release 3.1.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "gen_surv: Survival Data Simulation in Python",
   "upload_type": "software",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "publication_date": "2026-08-25",
   "description": "<p><strong>gen_surv</strong> generates synthetic time-to-event datasets from twelve models &mdash; proportional hazards, accelerated failure time, competing risks, cure fractions, piecewise hazards, recurrent events and two illness-death processes &mdash; so that an estimator can be tested against parameters the user chose. Alongside the data it can return the ground truth a real dataset could never contain: the coefficients actually used, latent event and censoring times, cure status and transition times. Inspired by the R package <a href=\"https://cran.r-project.org/package=genSurv\">genSurv</a> and extended well past it.</p>",
   "creators": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v3.1.0 (2026-08-28)
 
 Property-based tests across all twelve generators, and the two `tdcm` defects
 they found.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ message: "If you use this software, please cite it using the metadata below."
 preferred-citation:
   type: software
   title: "gen_surv"
-  version: "3.0.0"
+  version: "3.1.0"
   url: "https://github.com/DiogoRibeiro7/genSurvPy"
   authors:
     - family-names: Ribeiro

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ A bug fix in a sampler changes the draws a seed produces, so **pin the version
 alongside the seed** for anything that must reproduce:
 
 ```text
-gen-surv==3.0.0
+gen-surv==3.1.0
 ```
 
 See
@@ -284,7 +284,7 @@ Work happens on `develop`; `main` carries releases. See
   title   = {gen_surv: Survival Data Simulation in Python},
   author  = {Diogo Ribeiro},
   url     = {https://github.com/DiogoRibeiro7/genSurvPy},
-  version = {3.0.0}
+  version = {3.1.0}
 }
 ```
 

--- a/docs/getting-started/reproducibility.md
+++ b/docs/getting-started/reproducibility.md
@@ -117,7 +117,7 @@ times up front. Those two generators changed for every seed.
 **If a result must be reproducible for a paper, pin the version:**
 
 ```
-gen-surv==3.0.0
+gen-surv==3.1.0
 ```
 
 and record it alongside the seed. Record both in the artefact itself where you

--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,7 @@ Several models draw their coefficients for you when you omit them, and
   title   = {gen_surv: Survival Data Simulation in Python},
   author  = {Diogo Ribeiro},
   url     = {https://github.com/DiogoRibeiro7/genSurvPy},
-  version = {3.0.0}
+  version = {3.1.0}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gen_surv"
-version = "3.0.0"
+version = "3.1.0"
 description = "Simulate survival data with a known truth: twelve models spanning proportional hazards, accelerated failure time, competing risks, cure fractions, recurrent events and multi-state processes"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
Version bumped to 3.1.0 in the seven places that carry it, verified locally with the same consistency check `publish.yml` runs before it will upload anything.

## Why minor and not patch

`gen_tdcm` now raises where it previously returned a frame. A script passing those parameters will newly fail, and a patch would give no signal that anything observable moved.

## Why minor and not major

**The frozen regression baselines are unchanged.** That is the evidence that no valid call produces different data — the line 3.0.0 crossed when the multistate engine changed what `gen_cmm` and `gen_thmm` draw for a given seed. Seeds still reproduce here, and nothing that was correct stops working: the affected parameter combinations returned an observed event at time zero for every subject, or failed with a message quoting a range the model did not enforce.

## Contents

- **Two `tdcm` defects**, both found by the property-based suite rather than reported. The overflow one returned a frame with the right columns, the right dtypes and no NaN, in which every subject had `stop = 0.0` and `status = 1`.
- **`tests/test_properties.py`** — all twelve generators driven from Hypothesis: output invariants, the seed contract, and rejection of out-of-domain values, with a test that fails if a model is registered without a strategy.
- **Documentation** — the `corr` range on the TDCM page and in the docstring now match what is enforced.
- **Tooling** — CI runs on `develop` rather than only at the release boundary, the runtime dependency check that had never verified anything is fixed, the concurrency group can no longer let a PR run cancel a branch run, and the black pre-commit hook matches the dev group.

## Side effect worth having

PyPI still renders the 3.0.0 README, which never mentioned `gen_multistate` — the headline feature of that release. Uploading refreshes the project page, which is the only way that surface changes.

692 tests pass locally, up from 613 at 3.0.0.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases 3.1.0 by bumping the version in all seven files that carry it. `gen_tdcm` now raises where it previously returned a frame, so affected calls fail instead of silently returning invalid data.

**Migration**
- Scripts using the affected `gen_tdcm` parameter combinations must handle the new exception.

**Also included**
- Adds property-based tests covering all twelve generators.
- Fixes two `tdcm` defects: an overflow that returned `stop = 0.0` for every subject, and `corr` accepting endpoints the Gaussian copula cannot take.
- Corrects the documented `corr` range.
- CI now runs on `develop`, the runtime dependency check is fixed, and the concurrency group no longer lets PR runs cancel branch runs.
- Publishing refreshes the PyPI README, which still shows 3.0.0 and omits `gen_multistate`.

<sup>Written for commit f39f7f7c20463836ac504877de896d8744d5dea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

