### PR TITLE
Fix research pre-freeze integrity gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,13 @@ papers/
 research/*/results/raw/pilot.parquet
 research/*/results/processed/
 research/*/results/figures/
+
+# LaTeX build byproducts from research manuscripts.
+research/*/paper/*.aux
+research/*/paper/*.bbl
+research/*/paper/*.blg
+research/*/paper/*.fdb_latexmk
+research/*/paper/*.fls
+research/*/paper/*.out
+research/*/paper/*.pdf
+research/*/paper/*.synctex.gz

--- a/research/discrimination-not-calibration/config/metrics.yaml
+++ b/research/discrimination-not-calibration/config/metrics.yaml
@@ -11,6 +11,8 @@ time_grid_quantiles:
 - 0.9
 metrics:
 - mise
+- normalised_mise
+- root_mean_integrated_squared_error
 - miae
 - mean_absolute_survival_error
 - c_index_harrell

--- a/research/discrimination-not-calibration/paper/references.bib
+++ b/research/discrimination-not-calibration/paper/references.bib
@@ -223,13 +223,15 @@
   doi     = {10.1016/j.compbiomed.2025.111176}
 }
 
-@article{lillelund2025stop,
+@inproceedings{lillelund2026stop,
   author  = {Lillelund, Christian Marius and Qi, Shi-Ang and Greiner, Russell and
              Pedersen, Christian Fischer},
-  title   = {Stop Chasing the {C}-index: This Is How We Should Evaluate Our
-             Survival Models},
-  year    = {2025},
-  note    = {Preprint / submitted manuscript},
+  title   = {Position: Stop Chasing the {C}-index when Evaluating Survival
+             Analysis Models},
+  booktitle = {Proceedings of the 43rd International Conference on Machine
+               Learning},
+  year    = {2026},
+  note    = {ICML 2026 Position Paper Track, Spotlight},
   doi     = {10.48550/arXiv.2506.02075}
 }
 

--- a/research/discrimination-not-calibration/paper/sections/introduction.tex
+++ b/research/discrimination-not-calibration/paper/sections/introduction.tex
@@ -15,7 +15,7 @@
 % 2. That discrimination and calibration can disagree is KNOWN. Say so here,
 %    plainly and early, with citations. Do not stage it as a discovery. See
 %    \citet{austin2020graphical}, \citet{sonabend2022chacking},
-%    \citet{birolo2025beyond}, \citet{lillelund2025stop}.
+%    \citet{birolo2025beyond}, \citet{lillelund2026stop}.
 %
 % 3. The gap: all of that work evaluates against censored observations, which
 %    do not contain the true conditional survival function. So the size of the

--- a/research/discrimination-not-calibration/paper/sections/related_work.tex
+++ b/research/discrimination-not-calibration/paper/sections/related_work.tex
@@ -8,10 +8,10 @@
 % When written, this section must do three things:
 %
 % 1. State what \citet{austin2020graphical}, \citet{sonabend2022chacking},
-%    \citet{birolo2025beyond} and \citet{lillelund2025stop} each establish,
+%    \citet{birolo2025beyond} and \citet{lillelund2026stop} each establish,
 %    accurately and without hedging. \citet{birolo2025beyond} is the nearest
 %    competitor and explicitly reports high concordance alongside poor
-%    calibration under non-proportional hazards; \citet{lillelund2025stop} is
+%    calibration under non-proportional hazards; \citet{lillelund2026stop} is
 %    close enough in title that the distinction must be unmistakable.
 %
 % 2. Place the evaluation measures: \citet{harrell1982evaluating} and

--- a/research/discrimination-not-calibration/protocol/estimands.md
+++ b/research/discrimination-not-calibration/protocol/estimands.md
@@ -59,10 +59,19 @@ $$
 \mathrm{MIAE} \;=\; \frac{1}{n}\sum_{i=1}^{n} \mathrm{IAE}_i .
 $$
 
-**MISE is the primary outcome.** MIAE is reported alongside it because
-$\mathrm{MIAE}/\tau$ is a mean absolute error in survival *probability*, which
-a reader can judge against a clinical or actuarial tolerance. A squared error
-integrated over time cannot be read that way.
+Raw MISE is the primary within-scenario loss. Cross-mechanism figures and
+headline summaries use the horizon-normalised squared loss
+
+$$
+\mathrm{nMISE} = \mathrm{MISE}/\tau,
+\qquad
+\mathrm{RMISE} = \sqrt{\mathrm{nMISE}} .
+$$
+
+RMISE is on the survival-probability scale and is comparable across mechanisms
+whose $\tau$ differs. MIAE is reported alongside it because
+$\mathrm{MIAE}/\tau$ is a mean absolute error in survival probability, which a
+reader can judge against a clinical or actuarial tolerance.
 
 Both are computed on an independent evaluation sample drawn from the same
 mechanism, never on the data the model was fitted to.
@@ -95,11 +104,13 @@ differ, the ranking itself depends on the horizon, which is worth seeing.
 
 ## 4. Prediction error and calibration
 
-The Brier score at $t$ and its integral over the grid, with
-inverse-probability-of-censoring weights, and a grouped calibration error:
+The Brier score at $t$ and its integral over a fixed scenario-level IPCW grid,
+with inverse-probability-of-censoring weights, and a grouped calibration error:
 subjects are split into deciles of $\hat S_i(\tau)$, observed survival within
-each is estimated by Kaplan–Meier, and the size-weighted mean absolute gap is
-reported.
+each is estimated by Kaplan-Meier, and the size-weighted mean absolute gap is
+reported. If a replication cannot support the prespecified IPCW grid, its IBS
+and mean AUC are recorded as unavailable; the grid is not shortened after the
+replication is observed.
 
 D-calibration is reported as a distributional diagnostic, not as a like-for-like
 comparative primary measure for all estimators. Haider et al.'s theorem assumes
@@ -197,6 +208,11 @@ quantity on the scale of the chosen loss, and the region is reported as a
 function of $\epsilon$ over a range, conditional on the DGPs studied, the
 horizon $\tau$ and the loss. What counts as an adequate approximation is an
 application's judgement, not a statistical constant.
+
+The headline quantity is the 90th percentile of RMISE conditional on bins of a
+conventional metric, primarily Harrell's C-index. This reports the upper tail of
+truth-error compatible with similar conventional metric values, which is the
+measurement question of the study.
 
 ---
 

--- a/research/discrimination-not-calibration/protocol/preregistration.md
+++ b/research/discrimination-not-calibration/protocol/preregistration.md
@@ -57,19 +57,23 @@ and H4 concern where it bites and how far it goes.
 
 **H1.** Concordance and recovery of the true survival function are weakly
 related across misspecified scenarios. Formally, the correlation between the
-C-index and MISE across cells is small in magnitude.
+C-index and RMISE across cells has absolute Spearman rank correlation below
+0.30. Pearson correlation is reported as a sensitivity summary, not as the
+decision rule.
 
 **H2.** There exist scenarios in which an estimator's concordance is at or above
-that of a correctly specified reference while its MISE is larger by an order of
+that of a correctly specified reference while its nMISE is larger by an order of
 magnitude.
 
 **H3.** Mechanisms that break proportional hazards structurally — a
 non-monotone hazard, and a survival plateau from a cured fraction — produce
-larger MISE for proportional-hazards estimators than mechanisms that only
+larger RMISE for proportional-hazards estimators than mechanisms that only
 change the baseline's shape.
 
 **H4.** Censoring degrades absolute probability recovery more than it degrades
-ranking.
+ranking. Operationally, the contrast between 70% and 10% target censoring is
+larger on mean RMISE than on mean Harrell C-index after each metric is
+standardised by its across-cell standard deviation.
 
 These are directional statements, and the study may refute any of them. The
 pilot is consistent with H1 and H2 (see §7); that is a reason to run the
@@ -114,8 +118,11 @@ there described as indistinguishable rather than as findings.
 
 **Primary:** MISE, the integrated squared error between the predicted and the
 true conditional survival function over $[0, \tau]$, on an independent
-evaluation sample. Under the contribution stated in §1 this is not one metric
-among several: it is the reference against which the conventional metrics are
+evaluation sample. Raw MISE is used for within-scenario comparisons; nMISE and
+RMISE are used for cross-mechanism figures, adequacy summaries and headline
+claims so that different values of $\tau$ do not change the scale of the
+estimand. Under the contribution stated in §1 this is not one metric among
+several: it is the reference against which the conventional metrics are
 assessed.
 
 **Secondary:** MIAE and its horizon-normalised form; Harrell and Uno
@@ -142,6 +149,12 @@ study claims to detect.
 Recalibrating per replicate would make the mechanism random, so replicates
 would not be draws from one scenario.
 
+**The IPCW interval is resolved once per scenario and frozen.** Brier and
+time-dependent AUC implementations require evaluation times inside observed
+follow-up support. The production run uses the prespecified scenario-level
+grid; a replication that cannot support it records IBS and mean AUC as
+unavailable rather than shortening the interval after seeing that replication.
+
 **Cured subjects are excluded from the $\tau$ quantile.** `gen_mixture_cure`
 records a cured subject's event time as `max_time * 100`, a finite sentinel
 meaning "never fails". Counting it put $\tau$ at 1000 for `mixture_cure` where
@@ -165,6 +178,11 @@ at a single threshold. $\epsilon$ is not presented as a universal constant; its
 interpretation is conditional on the loss, the mechanism, the horizon and the
 application.
 
+The headline number is the 90th percentile of RMISE conditional on bins of a
+conventional metric, primarily Harrell's C-index. This answers the operational
+question "how large can truth-error be among rows with similar conventional
+metric values?" without turning a correlation coefficient into the claim.
+
 No inferential test is used to declare an estimator superior. Conclusions are
 conditional on the mechanisms studied, and no claim of general superiority will
 be made.
@@ -180,7 +198,8 @@ production rows.
 - Spread in MISE: estimator 6.4×, mechanism 6.1×, censoring 3.2×, $n$ 1.7×. No
   factor is redundant, which is why none was dropped; two interior *levels*
   were.
-- **correlation(C-index, MISE) $= -0.116$** across cells.
+- **correlation(C-index, MISE) $= -0.116$** across cells. This is retained as a
+  pilot diagnostic; production H1 is defined on RMISE as above.
 - On `aft_ln`, Cox at $C = 0.712$ had MISE 0.0408 while Cox at $C = 0.672$ had
   MISE 0.0025.
 
@@ -194,10 +213,13 @@ run with eight workers is the same experiment as a run with one. Verified: a
 4-worker and a 1-worker run of the same cells produced bit-identical seeds,
 MISE, concordance, integrated Brier and calibration error.
 
-Before the production run, `protocol/experiment_lock.json` will freeze the
-design, the commit and the environment. The runner refuses to start against a
-mismatched lock. If package code affecting simulation changes after the freeze,
-that is a new experiment version, not a continuation.
+Before the production run, `scripts/freeze_experiment.py` writes
+`protocol/experiment_lock.json`, freezing the design, the prepared scenario
+values, the commit and the environment. The runner loads prepared scenarios
+from the lock and every production row carries the lock hash; resumption
+refuses rows with a missing or different lock hash. If package code affecting
+simulation changes after the freeze, that is a new experiment version, not a
+continuation.
 
 **The freeze has not happened, and no production run has been executed.**
 

--- a/research/discrimination-not-calibration/scripts/aggregate_results.py
+++ b/research/discrimination-not-calibration/scripts/aggregate_results.py
@@ -20,6 +20,10 @@ Writes to ``results/processed/``:
     Excess loss of each estimator over the reference, across a range of
     epsilon, for the adequacy region, with paired MCSEs.
 
+``headline.parquet``
+    Conditional upper-tail normalised truth loss among rows with comparable
+    conventional metric values.
+
 Nothing here decides anything. It aggregates and reports uncertainty; the
 interpretation belongs in the paper, conditional on the DGPs studied.
 """
@@ -39,11 +43,12 @@ from survival_misspec.aggregation import (  # noqa: E402
     adequacy_region_from_pairs,
     aggregate,
     failure_rates,
+    headline_metric_gap,
     paired_differences,
     read_raw,
 )
 
-EPSILONS = (0.001, 0.005, 0.01, 0.025, 0.05)
+EPSILONS = (0.01, 0.025, 0.05, 0.10, 0.20)
 
 
 def main() -> int:
@@ -88,7 +93,13 @@ def main() -> int:
     frames = []
     for epsilon in EPSILONS:
         try:
-            frames.append(adequacy_region_from_pairs(paired, epsilon=epsilon))
+            frames.append(
+                adequacy_region_from_pairs(
+                    paired,
+                    loss="root_mean_integrated_squared_error",
+                    epsilon=epsilon,
+                )
+            )
         except ValueError as error:
             print(f"adequacy        skipped at epsilon={epsilon}: {error}")
             break
@@ -96,6 +107,17 @@ def main() -> int:
         adequacy = pd.concat(frames, ignore_index=True)
         adequacy.to_parquet(out / "adequacy.parquet", index=False)
         print(f"adequacy        {len(adequacy)} rows over {len(EPSILONS)} epsilons")
+
+    try:
+        headline = headline_metric_gap(raw)
+    except ValueError as error:
+        print(f"headline        skipped: {error}")
+    else:
+        if headline.empty:
+            print("headline        skipped: no scored rows")
+        else:
+            headline.to_parquet(out / "headline.parquet", index=False)
+            print(f"headline        {len(headline)} bins -> {out / 'headline.parquet'}")
 
     return 0
 

--- a/research/discrimination-not-calibration/scripts/check_grid_convergence.py
+++ b/research/discrimination-not-calibration/scripts/check_grid_convergence.py
@@ -1,0 +1,128 @@
+"""Check truth-loss sensitivity to the evaluation grid resolution.
+
+    python scripts/check_grid_convergence.py --config config --out results/grid_convergence.parquet
+
+The production config uses 51 time points. This diagnostic reruns matched cells
+at 51, 201 and 801 points and reports the difference from the 801-point value,
+so the freeze can document whether the production grid is adequate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pandas as pd
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from survival_misspec.config import load_study  # noqa: E402
+from survival_misspec.experiments import prepare_scenario, run_cell  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(HERE.parent / "config"))
+    parser.add_argument(
+        "--out", default=str(HERE.parent / "results" / "grid_convergence.parquet")
+    )
+    parser.add_argument("--grid-points", type=int, nargs="+", default=[51, 201, 801])
+    parser.add_argument("--calibration-n", type=int, default=20000)
+    parser.add_argument("--replications", type=int, default=1)
+    parser.add_argument("--max-scenarios", type=int, default=None)
+    parser.add_argument("--estimators", nargs="*", default=None)
+    arguments = parser.parse_args()
+
+    study = load_study(arguments.config)
+    grid_points = sorted(set(arguments.grid_points))
+    if len(grid_points) < 2:
+        raise SystemExit("need at least two grid sizes")
+    reference_grid = grid_points[-1]
+
+    scenarios = list(study.scenarios)
+    if arguments.max_scenarios is not None:
+        scenarios = scenarios[: arguments.max_scenarios]
+    estimators = [
+        estimator
+        for estimator in study.estimators
+        if arguments.estimators is None
+        or estimator.estimator_id in set(arguments.estimators)
+    ]
+
+    rows: list[dict[str, object]] = []
+    for scenario in scenarios:
+        prepared_by_grid = {}
+        for points in grid_points:
+            metrics = replace(study.metrics, n_time_points=points)
+            prepared = prepare_scenario(
+                scenario, metrics, calibration_n=arguments.calibration_n
+            )
+            if prepared.feasible:
+                prepared_by_grid[points] = prepared
+        if reference_grid not in prepared_by_grid:
+            continue
+
+        for estimator in estimators:
+            for replication_id in range(arguments.replications):
+                by_grid = {}
+                for points, prepared in prepared_by_grid.items():
+                    row = run_cell(
+                        prepared,
+                        estimator,
+                        replication_id,
+                        study.master_seed,
+                    )
+                    if row.get("scored"):
+                        by_grid[points] = row
+                if reference_grid not in by_grid:
+                    continue
+                reference = by_grid[reference_grid]
+                for points, row in by_grid.items():
+                    rows.append(
+                        {
+                            "scenario_id": scenario.scenario_id,
+                            "estimator_id": estimator.estimator_id,
+                            "replication_id": replication_id,
+                            "n_time_points": points,
+                            "reference_n_time_points": reference_grid,
+                            "mise": row["mise"],
+                            "rmise": row["root_mean_integrated_squared_error"],
+                            "mise_reference": reference["mise"],
+                            "rmise_reference": reference[
+                                "root_mean_integrated_squared_error"
+                            ],
+                            "mise_absolute_difference": abs(
+                                row["mise"] - reference["mise"]
+                            ),
+                            "rmise_absolute_difference": abs(
+                                row["root_mean_integrated_squared_error"]
+                                - reference["root_mean_integrated_squared_error"]
+                            ),
+                        }
+                    )
+
+    if not rows:
+        print("no scored grid-convergence rows")
+        return 1
+
+    out = Path(arguments.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame.from_records(rows)
+    frame.to_parquet(out, index=False)
+    print(f"written {len(frame)} rows -> {out}")
+    summary = (
+        frame[frame["n_time_points"] != reference_grid]
+        .groupby("n_time_points")[
+            ["mise_absolute_difference", "rmise_absolute_difference"]
+        ]
+        .max()
+    )
+    print(summary.to_string())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/discrimination-not-calibration/scripts/freeze_experiment.py
+++ b/research/discrimination-not-calibration/scripts/freeze_experiment.py
@@ -1,0 +1,66 @@
+"""Freeze the production experiment design into an experiment lock.
+
+    python scripts/freeze_experiment.py --config config --out protocol/experiment_lock.json
+
+This command is the only supported way to create the production lock: it
+prepares every scenario exactly once, records feasible and infeasible scenarios,
+and writes the hash that production rows must carry when they are resumed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from survival_misspec.config import load_study  # noqa: E402
+from survival_misspec.experiments import prepare_scenario  # noqa: E402
+from survival_misspec.validation import write_lock  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(HERE.parent / "config"))
+    parser.add_argument(
+        "--out", default=str(HERE.parent / "protocol" / "experiment_lock.json")
+    )
+    parser.add_argument("--protocol-version", default="0.1.0")
+    parser.add_argument("--calibration-n", type=int, default=20000)
+    parser.add_argument("--notes", default="")
+    parser.add_argument(
+        "--allow-dirty-tree",
+        action="store_true",
+        help="permit a lock from uncommitted code for dry runs only",
+    )
+    arguments = parser.parse_args()
+
+    study = load_study(arguments.config)
+    prepared = []
+    print(f"study hash    {study.hash}")
+    print(f"scenarios     {len(study.scenarios)}")
+    for scenario in study.scenarios:
+        ready = prepare_scenario(
+            scenario, study.metrics, calibration_n=arguments.calibration_n
+        )
+        prepared.append(ready.as_record())
+        status = "OK" if ready.feasible else "SKIP"
+        print(f"  {status} {ready.scenario_id}")
+
+    lock = write_lock(
+        arguments.out,
+        study,
+        prepared,
+        arguments.protocol_version,
+        notes=arguments.notes,
+        allow_dirty_tree=arguments.allow_dirty_tree,
+    )
+    print(f"written       {arguments.out}")
+    print(f"lock hash     {lock.lock_hash}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/discrimination-not-calibration/scripts/make_config.py
+++ b/research/discrimination-not-calibration/scripts/make_config.py
@@ -61,7 +61,7 @@ DGP_BUILDERS = {
     },
     "mixture_cure": lambda b: {
         "betas_survival": [b, -b / 2],
-        "betas_cure": [b / 2, 0.1],
+        "betas_cure": [b / 2, b / 5],
         "cure_fraction": 0.3,
         "baseline_hazard": 0.7,
         "model_cens": "uniform",
@@ -182,6 +182,8 @@ METRICS = {
     "time_grid_quantiles": [0.1, 0.25, 0.5, 0.75, 0.9],
     "metrics": [
         "mise",
+        "normalised_mise",
+        "root_mean_integrated_squared_error",
         "miae",
         "mean_absolute_survival_error",
         "c_index_harrell",

--- a/research/discrimination-not-calibration/scripts/make_figures.py
+++ b/research/discrimination-not-calibration/scripts/make_figures.py
@@ -44,6 +44,10 @@ COLOURS = {
     "gradient_boosted": "#CC79A7",
     "royston_parmar": "#56B4E9",
 }
+TRUTH_LOSS = "root_mean_integrated_squared_error"
+TRUTH_LOSS_MEAN = f"{TRUTH_LOSS}_mean"
+TRUTH_LOSS_MCSE = f"{TRUTH_LOSS}_mcse"
+TRUTH_LOSS_LABEL = "RMISE against the true survival function"
 MARKERS = {
     "cox_ph": "o",
     "weibull_aft": "s",
@@ -109,8 +113,8 @@ def _summarise_factor(block: pd.DataFrame, factor: str) -> pd.DataFrame:
     """Average scenario means by factor with MCSEs propagated."""
     rows = []
     for value, factor_block in block.groupby(factor):
-        means = pd.to_numeric(factor_block["mise_mean"], errors="coerce")
-        mcse = pd.to_numeric(factor_block["mise_mcse"], errors="coerce")
+        means = pd.to_numeric(factor_block[TRUTH_LOSS_MEAN], errors="coerce")
+        mcse = pd.to_numeric(factor_block[TRUTH_LOSS_MCSE], errors="coerce")
         keep = means.notna()
         if not keep.any():
             continue
@@ -119,7 +123,7 @@ def _summarise_factor(block: pd.DataFrame, factor: str) -> pd.DataFrame:
         rows.append(
             {
                 factor: value,
-                "mise": float(means.mean()),
+                "truth_loss": float(means.mean()),
                 "mcse": float(math.sqrt(float((mcse**2).sum())) / len(means)),
             }
         )
@@ -141,24 +145,24 @@ def figure_discrimination_vs_truth(
     consistent with a wide range of distance from the truth, and the width of
     that range is the quantity the study reports.
     """
-    if not _require(summary, ["c_index_harrell_mean", "mise_mean"], "fig1"):
+    if not _require(summary, ["c_index_harrell_mean", TRUTH_LOSS_MEAN], "fig1"):
         return
 
     figure, axis = plt.subplots(figsize=(5.2, 4.0))
     for estimator, block in summary.groupby("estimator_id"):
         axis.plot(
-            block["c_index_harrell_mean"], block["mise_mean"], **_style(estimator)
+            block["c_index_harrell_mean"], block[TRUTH_LOSS_MEAN], **_style(estimator)
         )
 
     axis.set_yscale("log")
     axis.set_xlabel("Harrell C-index")
-    axis.set_ylabel("MISE against the true survival function (log scale)")
+    axis.set_ylabel(f"{TRUTH_LOSS_LABEL} (log scale)")
     axis.set_title("Discrimination and truth-recovery metrics")
     # Below the axes: the interesting part of this figure is the vertical
     # spread at a fixed C-index, and a legend sitting in it hides the argument.
     axis.legend(fontsize=7, ncol=4, loc="upper center", bbox_to_anchor=(0.5, -0.13))
 
-    finite = summary[["c_index_harrell_mean", "mise_mean"]].dropna()
+    finite = summary[["c_index_harrell_mean", TRUTH_LOSS_MEAN]].dropna()
     if len(finite) > 2:
         correlation = finite.corr().iloc[0, 1]
         axis.annotate(
@@ -213,7 +217,7 @@ def _factor_panel(
     exploratory: bool,
     logx: bool = False,
 ) -> None:
-    if not _require(summary, [factor, "mise_mean", "mise_mcse"], name):
+    if not _require(summary, [factor, TRUTH_LOSS_MEAN, TRUTH_LOSS_MCSE], name):
         return
 
     figure, axis = plt.subplots(figsize=(5.4, 4.0))
@@ -225,7 +229,7 @@ def _factor_panel(
         style["linestyle"] = "-"
         axis.errorbar(
             grouped[factor],
-            grouped["mise"],
+            grouped["truth_loss"],
             yerr=grouped["mcse"],
             capsize=2,
             linewidth=1.2,
@@ -236,7 +240,7 @@ def _factor_panel(
         axis.set_xscale("log")
     axis.set_yscale("log")
     axis.set_xlabel(xlabel)
-    axis.set_ylabel("MISE (log scale)")
+    axis.set_ylabel(f"{TRUTH_LOSS_LABEL} (log scale)")
     axis.set_title(f"Recovery of the truth against {xlabel.lower()}")
     axis.legend(fontsize=7, ncol=4, loc="upper center", bbox_to_anchor=(0.5, -0.13))
     _save(figure, name, out, exploratory)
@@ -274,7 +278,7 @@ def figure_adequacy(adequacy: pd.DataFrame, out: Path, exploratory: bool) -> Non
         axis.plot(block["epsilon"], block["within_epsilon"], **style)
 
     axis.set_xscale("log")
-    axis.set_xlabel("$\\epsilon$ (tolerance on MISE)")
+    axis.set_xlabel("$\\epsilon$ (tolerance on RMISE)")
     axis.set_ylabel("Share of scenarios within $\\epsilon$ of the reference")
     axis.set_title("Adequacy region as the tolerance varies")
     axis.set_ylim(-0.02, 1.02)
@@ -288,13 +292,52 @@ def figure_adequacy(adequacy: pd.DataFrame, out: Path, exploratory: bool) -> Non
 
 
 def figure_illustrative_curves(raw: pd.DataFrame, out: Path, exploratory: bool) -> None:
-    """One scenario where discrimination looks fine and the curves are not.
+    """One scenario where discrimination looks fine and truth loss is high.
 
-    Chosen automatically as the cell with the highest MISE among those whose
-    C-index is at or above the median, so the choice is reproducible and cannot
-    be the most flattering example someone went looking for.
+    Chosen automatically as the cell with the highest median RMISE among those
+    whose C-index is at or above the median, so the choice is reproducible and
+    cannot be the most flattering example someone went looking for.
     """
-    print("  fig7: skipped, illustrative curve export is not implemented")
+    needed = ["scenario_id", "estimator_id", "c_index_harrell", TRUTH_LOSS, "scored"]
+    if not _require(raw, needed, "fig7"):
+        return
+
+    scored = raw[raw["scored"].fillna(False)].copy()
+    scored["c_index_harrell"] = pd.to_numeric(
+        scored["c_index_harrell"], errors="coerce"
+    )
+    scored[TRUTH_LOSS] = pd.to_numeric(scored[TRUTH_LOSS], errors="coerce")
+    scored = scored.dropna(subset=["c_index_harrell", TRUTH_LOSS])
+    if scored.empty:
+        print("  fig7: skipped, no scored rows with truth loss and C-index")
+        return
+
+    threshold = float(scored["c_index_harrell"].median())
+    candidates = scored[scored["c_index_harrell"] >= threshold]
+    cell_scores = (
+        candidates.groupby(["scenario_id", "estimator_id"])[TRUTH_LOSS]
+        .median()
+        .sort_values(ascending=False)
+    )
+    if cell_scores.empty:
+        print("  fig7: skipped, no high-discrimination candidate cell")
+        return
+
+    scenario_id, estimator_id = cell_scores.index[0]
+    block = scored[
+        (scored["scenario_id"] == scenario_id)
+        & (scored["estimator_id"] == estimator_id)
+    ]
+
+    figure, axis = plt.subplots(figsize=(5.2, 4.0))
+    style = _style(str(estimator_id))
+    axis.plot(block["c_index_harrell"], block[TRUTH_LOSS], **style)
+    axis.axvline(threshold, color="0.45", linewidth=0.8, linestyle="--")
+    axis.set_yscale("log")
+    axis.set_xlabel("Harrell C-index")
+    axis.set_ylabel(f"{TRUTH_LOSS_LABEL} (log scale)")
+    axis.set_title(f"Illustrative high-loss cell: {scenario_id}")
+    _save(figure, "fig7_illustrative_high_loss_cell", out, exploratory)
 
 
 # ---------------------------------------------------------------------------

--- a/research/discrimination-not-calibration/scripts/make_tables.py
+++ b/research/discrimination-not-calibration/scripts/make_tables.py
@@ -149,7 +149,12 @@ def table_main_results(summary: pd.DataFrame, out: Path) -> None:
     overlap are not distinguishable at this replication count, and the table is
     laid out so a reader can see that rather than having to be told.
     """
-    needed = ["dgp", "estimator_id", "mise_mean", "mise_mcse"]
+    needed = [
+        "dgp",
+        "estimator_id",
+        "root_mean_integrated_squared_error_mean",
+        "root_mean_integrated_squared_error_mcse",
+    ]
     missing = [c for c in needed if c not in summary.columns]
     if missing:
         print(f"  table3: skipped, missing {missing}")
@@ -159,7 +164,11 @@ def table_main_results(summary: pd.DataFrame, out: Path) -> None:
     for (dgp, estimator_id), block in summary.groupby(["dgp", "estimator_id"]):
         record = {"dgp": dgp, "estimator_id": estimator_id}
         for label, mean_column, mcse_column in (
-            ("mise", "mise_mean", "mise_mcse"),
+            (
+                "rmise",
+                "root_mean_integrated_squared_error_mean",
+                "root_mean_integrated_squared_error_mcse",
+            ),
             ("c_index", "c_index_harrell_mean", "c_index_harrell_mcse"),
             ("ibs", "integrated_brier_score_mean", "integrated_brier_score_mcse"),
             ("calib", "calibration_error_mean", "calibration_error_mcse"),
@@ -179,7 +188,7 @@ def table_main_results(summary: pd.DataFrame, out: Path) -> None:
         r"\label{tab:main}",
         r"\begin{tabular}{llrrrr}",
         r"\toprule",
-        r"Mechanism & Estimator & MISE & C-index & IBS & Calibration \\",
+        r"Mechanism & Estimator & RMISE & C-index & IBS & Calibration \\",
         r"\midrule",
     ]
     for dgp, block in grouped.groupby("dgp"):
@@ -187,7 +196,7 @@ def table_main_results(summary: pd.DataFrame, out: Path) -> None:
             label = f"\\texttt{{{_escape(dgp)}}}" if position == 0 else ""
             body.append(
                 f"{label} & \\texttt{{{_escape(row.estimator_id)}}} & "
-                f"{_pm(row.mise, row.mise_mcse, 5)} & "
+                f"{_pm(row.rmise, row.rmise_mcse, 4)} & "
                 f"{_pm(row.c_index, row.c_index_mcse, 3)} & "
                 f"{_pm(row.ibs, row.ibs_mcse, 3)} & "
                 f"{_pm(row.calib, row.calib_mcse, 3)} \\\\"
@@ -227,7 +236,7 @@ def table_parameter_recovery(summary: pd.DataFrame, out: Path) -> None:
         r"\label{tab:recovery}",
         r"\begin{tabular}{llrrr}",
         r"\toprule",
-        r"Mechanism & Estimator & Mean bias & Mean absolute bias & MISE \\",
+        r"Mechanism & Estimator & Mean bias & Mean absolute bias & RMISE \\",
         r"\midrule",
     ]
     for row in applicable.itertuples():
@@ -243,12 +252,17 @@ def table_parameter_recovery(summary: pd.DataFrame, out: Path) -> None:
             and not pd.isna(row.beta_bias_scalar_mcse)
             else row.beta_bias_mean_mcse
         )
+        rmise = _pm(
+            row.root_mean_integrated_squared_error_mean,
+            row.root_mean_integrated_squared_error_mcse,
+            4,
+        )
         body.append(
             f"\\texttt{{{_escape(str(row.dgp))}}} & "
             f"\\texttt{{{_escape(str(row.estimator_id))}}} & "
             f"{_pm(signed, signed_mcse, 4)} & "
             f"{_pm(row.beta_abs_bias_mean_mean, row.beta_abs_bias_mean_mcse, 4)} & "
-            f"{_pm(row.mise_mean, row.mise_mcse, 5)} \\\\"
+            f"{rmise} \\\\"
         )
     body += [r"\bottomrule", r"\end{tabular}", r"\end{table}", ""]
     _write(

--- a/research/discrimination-not-calibration/scripts/run_pilot.py
+++ b/research/discrimination-not-calibration/scripts/run_pilot.py
@@ -109,10 +109,14 @@ def main() -> int:
         )
 
     # ------------------------------------------------------------ what matters
-    section("Which factors move the primary loss (MISE)")
+    section("Which factors move the primary loss (RMISE)")
     scored = raw[raw["scored"].fillna(False)]
     for factor in ("dgp", "n", "target_censoring", "estimator_id"):
-        grouped = scored.groupby(factor)["mise"].mean().sort_values()
+        grouped = (
+            scored.groupby(factor)["root_mean_integrated_squared_error"]
+            .mean()
+            .sort_values()
+        )
         spread = grouped.max() / grouped.min() if grouped.min() > 0 else float("inf")
         print(f"\n  by {factor}  (max/min = {spread:.1f}x)")
         for key, value in grouped.items():
@@ -127,24 +131,31 @@ def main() -> int:
             "dgp",
             "estimator_id",
             "c_index_harrell_mean",
-            "mise_mean",
+            "root_mean_integrated_squared_error_mean",
             "mean_absolute_survival_error_mean",
             "calibration_error_mean",
         ]
     ]
     view = view.dropna(subset=["c_index_harrell_mean"])
     print(
-        f"\n  {'dgp':24} {'estimator':24} {'C':>7} {'MISE':>10} {'MAE_S':>8} {'calib':>8}"
+        f"\n  {'dgp':24} {'estimator':24} {'C':>7} {'RMISE':>10} {'MAE_S':>8} {'calib':>8}"
     )
-    for row in view.sort_values(["dgp", "mise_mean"]).itertuples():
+    for row in view.sort_values(
+        ["dgp", "root_mean_integrated_squared_error_mean"]
+    ).itertuples():
         print(
             f"  {row.dgp:24} {row.estimator_id:24} {row.c_index_harrell_mean:7.4f} "
-            f"{row.mise_mean:10.6f} {row.mean_absolute_survival_error_mean:8.4f} "
+            f"{row.root_mean_integrated_squared_error_mean:10.6f} "
+            f"{row.mean_absolute_survival_error_mean:8.4f} "
             f"{row.calibration_error_mean:8.4f}"
         )
 
-    correlation = view[["c_index_harrell_mean", "mise_mean"]].corr().iloc[0, 1]
-    print(f"\n  correlation(C-index, MISE) across cells = {correlation:+.3f}")
+    correlation = (
+        view[["c_index_harrell_mean", "root_mean_integrated_squared_error_mean"]]
+        .corr()
+        .iloc[0, 1]
+    )
+    print(f"\n  correlation(C-index, RMISE) across cells = {correlation:+.3f}")
     print("  A weak or positive correlation is the paper's phenomenon: ranking")
     print("  well and predicting probabilities well are not the same thing.")
 

--- a/research/discrimination-not-calibration/scripts/run_simulation.py
+++ b/research/discrimination-not-calibration/scripts/run_simulation.py
@@ -27,13 +27,19 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent / "src"))
 
 from survival_misspec.aggregation import (  # noqa: E402
+    compact_raw,
     completed_cells,
     write_raw,
 )
 from survival_misspec.config import load_study  # noqa: E402
-from survival_misspec.experiments import prepare_scenario, run_cell  # noqa: E402
+from survival_misspec.experiments import (  # noqa: E402
+    prepare_scenario,
+    prepared_scenario_from_record,
+    run_cell,
+)
 from survival_misspec.validation import (  # noqa: E402
     capture_provenance,
+    read_lock,
     verify_lock,
 )
 
@@ -66,6 +72,11 @@ def main() -> int:
     )
     parser.add_argument("--calibration-n", type=int, default=20000)
     parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="write one deterministic compact Parquet file after the run",
+    )
+    parser.add_argument(
         "--workers",
         type=int,
         default=1,
@@ -96,27 +107,46 @@ def main() -> int:
             for problem in problems:
                 print(f"  - {problem}")
             return 1
-        print(f"lock          verified against {arguments.lock}")
+        lock = read_lock(arguments.lock)
+        lock_hash = str(lock["lock_hash"])
+        print(f"lock          verified against {arguments.lock} ({lock_hash})")
     else:
+        lock = None
+        lock_hash = None
         print("lock          NONE (exploratory run; not a production result)")
 
     out = Path(arguments.out)
-    done = completed_cells(out)
+    done = completed_cells(out, lock_hash=lock_hash)
     if done:
         print(f"resuming      {len(done):,} cells already present in {out}")
 
-    print("\npreparing scenarios (calibrating censoring, fixing tau)...")
     prepared = []
     infeasible = []
-    for scenario in study.scenarios:
-        ready = prepare_scenario(
-            scenario, study.metrics, calibration_n=arguments.calibration_n
-        )
-        if ready.feasible:
-            prepared.append(ready)
-        else:
-            infeasible.append(ready)
-            print(f"  SKIP {ready.scenario_id}: {ready.reason}")
+    if lock is not None:
+        print("\nloading prepared scenarios from the experiment lock...")
+        records = {record["scenario_id"]: record for record in lock["scenarios"]}
+        for scenario in study.scenarios:
+            ready = prepared_scenario_from_record(
+                scenario, records[scenario.scenario_id]
+            )
+            if ready.feasible:
+                prepared.append(ready)
+            else:
+                infeasible.append(ready)
+                print(f"  SKIP {ready.scenario_id}: {ready.reason}")
+        if arguments.calibration_n != 20000:
+            print("  --calibration-n ignored for locked production runs")
+    else:
+        print("\npreparing scenarios (calibrating censoring, fixing tau)...")
+        for scenario in study.scenarios:
+            ready = prepare_scenario(
+                scenario, study.metrics, calibration_n=arguments.calibration_n
+            )
+            if ready.feasible:
+                prepared.append(ready)
+            else:
+                infeasible.append(ready)
+                print(f"  SKIP {ready.scenario_id}: {ready.reason}")
 
     print(f"  {len(prepared)} feasible, {len(infeasible)} infeasible")
     if not prepared:
@@ -146,6 +176,7 @@ def main() -> int:
         row["git_commit"] = provenance.git_commit
         row["gen_surv_version"] = provenance.gen_surv_version
         row["is_production"] = bool(arguments.lock)
+        row["lock_hash"] = lock_hash
         buffer.append(row)
         ran += 1
         if len(buffer) >= FLUSH_EVERY:
@@ -193,6 +224,9 @@ def main() -> int:
 
     elapsed = time.perf_counter() - started
     print(f"\ndone: ran {ran:,} cells in {elapsed / 60:.1f} min -> {out}")
+    if arguments.compact:
+        compacted = compact_raw(out)
+        print(f"compacted     {compacted}")
     return 0
 
 

--- a/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
@@ -36,11 +36,13 @@ __all__ = [
     "replications_for_precision",
     "aggregate",
     "paired_differences",
+    "headline_metric_gap",
     "failure_rates",
     "adequacy_region",
     "adequacy_region_from_pairs",
     "write_raw",
     "read_raw",
+    "compact_raw",
     "completed_cells",
 ]
 
@@ -48,6 +50,8 @@ __all__ = [
 #: identifier, a diagnostic string, or already a summary.
 METRIC_COLUMNS = (
     "mise",
+    "normalised_mise",
+    "root_mean_integrated_squared_error",
     "miae",
     "mean_absolute_survival_error",
     "miae_p90",
@@ -231,6 +235,61 @@ def paired_differences(
     return pd.DataFrame.from_records(records)
 
 
+def headline_metric_gap(
+    raw: pd.DataFrame,
+    *,
+    conventional_metric: str = "c_index_harrell",
+    loss: str = "root_mean_integrated_squared_error",
+    bins: int = 10,
+    quantile: float = 0.90,
+) -> pd.DataFrame:
+    """Conditional upper-tail truth loss at comparable conventional metrics.
+
+    This is the operational headline for "how much truth-error is consistent
+    with a conventional metric": bin cells by the conventional metric and
+    report a high conditional quantile of the normalised truth loss.
+    """
+    needed = {conventional_metric, loss, "scored"}
+    missing = sorted(needed - set(raw.columns))
+    if missing:
+        raise ValueError(f"headline table missing columns: {missing}")
+
+    scored = raw[raw["scored"].fillna(False)].copy()
+    scored[conventional_metric] = pd.to_numeric(
+        scored[conventional_metric], errors="coerce"
+    )
+    scored[loss] = pd.to_numeric(scored[loss], errors="coerce")
+    scored = scored.dropna(subset=[conventional_metric, loss])
+    if scored.empty:
+        return pd.DataFrame()
+
+    try:
+        scored["_metric_bin"] = pd.qcut(
+            scored[conventional_metric], q=bins, duplicates="drop"
+        )
+    except ValueError:
+        scored["_metric_bin"] = pd.cut(scored[conventional_metric], bins=bins)
+
+    records: list[dict[str, object]] = []
+    for interval, block in scored.groupby("_metric_bin", observed=True):
+        values = block[loss].to_numpy(dtype=float)
+        records.append(
+            {
+                "metric": conventional_metric,
+                "loss": loss,
+                "quantile": quantile,
+                "metric_bin": str(interval),
+                "metric_min": float(block[conventional_metric].min()),
+                "metric_max": float(block[conventional_metric].max()),
+                "loss_quantile": float(np.quantile(values, quantile)),
+                "loss_median": float(np.median(values)),
+                "n": int(values.size),
+            }
+        )
+
+    return pd.DataFrame.from_records(records)
+
+
 def failure_rates(
     raw: pd.DataFrame, by: Sequence[str] = ("scenario_id", "estimator_id")
 ) -> pd.DataFrame:
@@ -406,16 +465,58 @@ def read_raw(path: Path | str) -> pd.DataFrame:
     return pd.concat(frames, ignore_index=True, sort=False)
 
 
-def completed_cells(path: Path | str) -> set[tuple[str, str, int]]:
+def compact_raw(path: Path | str, output: Path | str | None = None) -> Path:
+    """Write one deterministic Parquet file from all raw shards."""
+    target = Path(path)
+    frame = read_raw(target)
+    if frame.empty:
+        raise ValueError(f"no raw rows found in {target}")
+
+    sort_columns = [
+        column
+        for column in ("scenario_id", "estimator_id", "replication_id")
+        if column in frame.columns
+    ]
+    if sort_columns:
+        frame = frame.sort_values(sort_columns, kind="mergesort").reset_index(drop=True)
+
+    if output is None:
+        if target.is_dir():
+            output_path = target.parent / f"{target.name}.compact.parquet"
+        else:
+            output_path = target
+    else:
+        output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(output_path, index=False)
+    return output_path
+
+
+def completed_cells(
+    path: Path | str, *, lock_hash: str | None = None
+) -> set[tuple[str, str, int]]:
     """Which ``(scenario, estimator, replication)`` triples are already done.
 
     Resumption is by identity, not by count. Because seeds are derived from
     identifiers, a resumed run reproduces exactly the data an interrupted one
     would have produced, so a partially complete experiment is not tainted.
+    Production resumption also requires a matching lock hash; otherwise rows
+    from an exploratory or different frozen experiment cannot be reused.
     """
     frame = read_raw(path)
     if frame.empty:
         return set()
+    if lock_hash is not None:
+        if "lock_hash" not in frame.columns:
+            raise ValueError(
+                f"{path} contains rows without lock_hash; refusing production resume"
+            )
+        present = set(frame["lock_hash"].dropna().astype(str))
+        if present != {str(lock_hash)}:
+            raise ValueError(
+                f"{path} contains lock_hash values {sorted(present)}; "
+                f"expected {lock_hash}"
+            )
     return {
         (str(row.scenario_id), str(row.estimator_id), int(row.replication_id))
         for row in frame.itertuples()

--- a/research/discrimination-not-calibration/src/survival_misspec/estimators.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/estimators.py
@@ -61,6 +61,10 @@ class SurvivalEstimator(Protocol):
         self, X: NDArray[np.float64], times: NDArray[np.float64]
     ) -> NDArray[np.float64]: ...
 
+    def predict_survival_at_times(
+        self, X: NDArray[np.float64], times: NDArray[np.float64]
+    ) -> NDArray[np.float64]: ...
+
     def predict_risk(self, X: NDArray[np.float64]) -> NDArray[np.float64]: ...
 
     def coefficients(self) -> dict[str, float] | None: ...
@@ -122,6 +126,12 @@ class CoxPHAdapter:
         # lifelines returns times as the index and subjects as columns.
         return _clip_survival(predicted.to_numpy().T)
 
+    def predict_survival_at_times(self, X, times):  # type: ignore[no-untyped-def]
+        grid = np.unique(np.asarray(times, dtype=float))
+        surface = self.predict_survival(X, grid)
+        columns = np.searchsorted(grid, np.asarray(times, dtype=float), side="left")
+        return surface[np.arange(surface.shape[0]), columns]
+
     def predict_risk(self, X):  # type: ignore[no-untyped-def]
         return np.asarray(
             self._model.predict_partial_hazard(_frame(X)), dtype=float
@@ -149,6 +159,12 @@ class WeibullAFTAdapter:
         grid = np.asarray(times, dtype=float)
         predicted = self._model.predict_survival_function(_frame(X), times=grid)
         return _clip_survival(predicted.to_numpy().T)
+
+    def predict_survival_at_times(self, X, times):  # type: ignore[no-untyped-def]
+        grid = np.unique(np.asarray(times, dtype=float))
+        surface = self.predict_survival(X, grid)
+        columns = np.searchsorted(grid, np.asarray(times, dtype=float), side="left")
+        return surface[np.arange(surface.shape[0]), columns]
 
     def predict_risk(self, X):  # type: ignore[no-untyped-def]
         # Higher risk must mean earlier failure, so negate the expected time.
@@ -191,6 +207,22 @@ class _SksurvAdapter:
             surface[row][grid < function.x[0]] = 1.0
 
         return _clip_survival(surface)
+
+    def predict_survival_functions(self, X):  # type: ignore[no-untyped-def]
+        """Native scikit-survival step functions for exact-time metrics."""
+        return self._model.predict_survival_function(_frame(X).to_numpy())
+
+    def predict_survival_at_times(self, X, times):  # type: ignore[no-untyped-def]
+        functions = self.predict_survival_functions(X)
+        out = np.empty(len(functions), dtype=float)
+        for row, (function, time) in enumerate(
+            zip(functions, np.asarray(times, float))
+        ):
+            if time < function.x[0]:
+                out[row] = 1.0
+            else:
+                out[row] = float(function(min(float(time), float(function.x[-1]))))
+        return np.clip(out, 0.0, 1.0)
 
     def predict_risk(self, X):  # type: ignore[no-untyped-def]
         return np.asarray(

--- a/research/discrimination-not-calibration/src/survival_misspec/experiments.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/experiments.py
@@ -44,6 +44,7 @@ from .truth import true_survival
 __all__ = [
     "PreparedScenario",
     "prepare_scenario",
+    "prepared_scenario_from_record",
     "PARAMETER_CORRESPONDENCE",
     "parameter_recovery",
     "run_cell",
@@ -68,6 +69,7 @@ class PreparedScenario:
     params: Mapping[str, Any]
     tau: float
     time_grid: tuple[float, ...]
+    ipcw_time_grid: tuple[float, ...]
     censoring_achieved: float
     feasible: bool
     reason: str = ""
@@ -88,6 +90,8 @@ class PreparedScenario:
             "misspecification": self.config.misspecification,
             "tau": self.tau,
             "n_time_points": len(self.time_grid),
+            "time_grid": list(self.time_grid),
+            "ipcw_time_grid": list(self.ipcw_time_grid),
             "params": dict(self.params),
             "feasible": self.feasible,
             "reason": self.reason,
@@ -134,6 +138,7 @@ def prepare_scenario(
             params=params,
             tau=float("nan"),
             time_grid=(),
+            ipcw_time_grid=(),
             censoring_achieved=calibration.achieved,
             feasible=False,
             reason="no finite latent event times; tau is undefined",
@@ -151,6 +156,7 @@ def prepare_scenario(
             params=params,
             tau=tau,
             time_grid=(),
+            ipcw_time_grid=(),
             censoring_achieved=calibration.achieved,
             feasible=False,
             reason=(
@@ -161,15 +167,64 @@ def prepare_scenario(
         )
 
     grid = tuple(np.linspace(0.0, tau, metrics.n_time_points).tolist())
+    observed = reference.data["time"].to_numpy(dtype=float)
+    lower = float(np.min(observed))
+    support_upper = float(np.max(observed))
+    ipcw_grid = tuple(
+        value
+        for value in grid
+        if value > lower and value <= tau and value < support_upper
+    )
 
     return PreparedScenario(
         config=scenario,
         params=params,
         tau=tau,
         time_grid=grid,
+        ipcw_time_grid=ipcw_grid,
         censoring_achieved=calibration.achieved,
         feasible=calibration.feasible,
         reason=calibration.reason,
+    )
+
+
+def prepared_scenario_from_record(
+    scenario: ScenarioConfig, record: Mapping[str, Any]
+) -> PreparedScenario:
+    """Rehydrate a prepared scenario from the experiment lock.
+
+    Production runs must not recalibrate censoring or recompute tau when they
+    resume. The lock contains the prepared values; this function turns them back
+    into the object `run_cell` expects and refuses stale or incomplete locks.
+    """
+    if record.get("scenario_id") != scenario.scenario_id:
+        raise ValueError(
+            f"lock record for {record.get('scenario_id')!r} cannot prepare "
+            f"scenario {scenario.scenario_id!r}"
+        )
+    if record.get("scenario_hash") != scenario.hash:
+        raise ValueError(
+            f"scenario {scenario.scenario_id!r} has changed since the lock was written"
+        )
+
+    required = ("params", "tau", "time_grid", "ipcw_time_grid", "feasible")
+    missing = [name for name in required if name not in record]
+    if missing:
+        raise ValueError(
+            f"prepared scenario {scenario.scenario_id!r} is missing {missing}"
+        )
+
+    return PreparedScenario(
+        config=scenario,
+        params=dict(record["params"]),
+        tau=float(record["tau"]),
+        time_grid=tuple(float(value) for value in record["time_grid"]),
+        ipcw_time_grid=tuple(float(value) for value in record["ipcw_time_grid"]),
+        censoring_achieved=float(
+            record.get("achieved_censoring", record.get("censoring_achieved", np.nan))
+        ),
+        feasible=bool(record["feasible"]),
+        reason=str(record.get("reason", "")),
     )
 
 
@@ -324,6 +379,10 @@ def run_cell(
         truth_surface = true_survival(
             scenario.dgp, grid, evaluation.truth, prepared.params
         )
+        survival_functions = None
+        predictor = getattr(fitted.model, "predict_survival_functions", None)
+        if predictor is not None:
+            survival_functions = predictor(evaluation.covariates)
 
         row.update(
             evaluate_all(
@@ -336,6 +395,8 @@ def run_cell(
                 train_event=train.event,
                 eval_time=evaluation.observed_time,
                 eval_event=evaluation.event,
+                prediction_error_times=np.asarray(prepared.ipcw_time_grid, dtype=float),
+                survival_functions=survival_functions,
             )
         )
         row["scored"] = True

--- a/research/discrimination-not-calibration/src/survival_misspec/metrics.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/metrics.py
@@ -21,7 +21,7 @@ afterwards would let the headline result be tuned.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -43,6 +43,8 @@ __all__ = [
     "antolini_concordance",
     "integrated_squared_error",
     "integrated_absolute_error",
+    "normalised_mise",
+    "root_mean_integrated_squared_error",
     "truth_recovery",
     "discrimination",
     "prediction_error",
@@ -110,9 +112,12 @@ def truth_recovery(
     """MISE, MIAE and the tail of the per-subject error distribution."""
     ise = integrated_squared_error(predicted, truth, times, tau)
     iae = integrated_absolute_error(predicted, truth, times, tau)
+    nmise = normalised_mise(ise, tau)
 
     return {
         "mise": float(np.mean(ise)),
+        "normalised_mise": float(nmise),
+        "root_mean_integrated_squared_error": float(np.sqrt(nmise)),
         "mise_sd": float(np.std(ise, ddof=1)) if ise.size > 1 else float("nan"),
         "miae": float(np.mean(iae)),
         "miae_p90": float(np.quantile(iae, 0.90)),
@@ -121,6 +126,19 @@ def truth_recovery(
         # survival probability, comparable across scenarios with different tau.
         "mean_absolute_survival_error": float(np.mean(iae) / tau),
     }
+
+
+def normalised_mise(ise: NDArray[np.float64], tau: float) -> float:
+    """Mean integrated squared error per unit time."""
+    if tau <= 0:
+        return float("nan")
+    return float(np.mean(ise) / tau)
+
+
+def root_mean_integrated_squared_error(ise: NDArray[np.float64], tau: float) -> float:
+    """RMISE, on the survival-probability scale and comparable across tau."""
+    nmise = normalised_mise(ise, tau)
+    return float(np.sqrt(nmise)) if np.isfinite(nmise) else float("nan")
 
 
 def discrimination(
@@ -169,6 +187,7 @@ def prediction_error(
     test_time: NDArray[np.float64],
     test_event: NDArray[np.bool_],
     tau: float,
+    evaluation_times: NDArray[np.float64] | None = None,
 ) -> dict[str, float]:
     """Brier score, integrated Brier score, and time-dependent AUC.
 
@@ -207,7 +226,53 @@ def prediction_error(
     out["brier_at_tau_time"] = float(tau) if tau_usable else float("nan")
     out["auc_at_tau_time"] = float(tau) if tau_usable else float("nan")
 
-    if usable.sum() < 2:
+    if evaluation_times is None:
+        sub_grid = grid[usable]
+        sub_predicted = predicted[:, usable]
+    else:
+        fixed_grid = np.asarray(evaluation_times, dtype=float)
+        if fixed_grid.size < 2:
+            out.update(
+                {
+                    "brier_at_tau": float("nan"),
+                    "integrated_brier_score": float("nan"),
+                    "auc_mean": float("nan"),
+                    "auc_at_tau": float("nan"),
+                    "prediction_error_note": (
+                        "fixed IPCW interval has fewer than two time points"
+                    ),
+                }
+            )
+            return out
+        supported = (
+            (fixed_grid > lower)
+            & (fixed_grid <= float(tau))
+            & (fixed_grid < support_upper)
+        )
+        if not bool(np.all(supported)):
+            out.update(
+                {
+                    "brier_at_tau": float("nan"),
+                    "integrated_brier_score": float("nan"),
+                    "auc_mean": float("nan"),
+                    "auc_at_tau": float("nan"),
+                    "prediction_error_note": (
+                        "replication does not support the fixed IPCW interval"
+                    ),
+                }
+            )
+            return out
+        columns = np.searchsorted(grid, fixed_grid, side="left")
+        if (
+            columns.size != fixed_grid.size
+            or np.any(columns >= grid.size)
+            or not np.allclose(grid[columns], fixed_grid)
+        ):
+            raise ValueError("fixed IPCW grid is not a subset of the prediction grid")
+        sub_grid = fixed_grid
+        sub_predicted = predicted[:, columns]
+
+    if sub_grid.size < 2:
         out.update(
             {
                 "brier_at_tau": float("nan"),
@@ -220,9 +285,6 @@ def prediction_error(
             }
         )
         return out
-
-    sub_grid = grid[usable]
-    sub_predicted = predicted[:, usable]
 
     try:
         _, scores = brier_score(train, test, sub_predicted, sub_grid)
@@ -392,6 +454,24 @@ def _survival_at_common_time(
     return out
 
 
+def _survival_from_functions(
+    functions: Sequence[Callable[[float], float]],
+    times: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Evaluate native survival functions without interpolating a coarse grid."""
+    out = np.empty(len(functions), dtype=float)
+    for row, (function, time) in enumerate(zip(functions, np.asarray(times, float))):
+        support = getattr(function, "x", None)
+        if support is not None and len(support):
+            if time < support[0]:
+                out[row] = 1.0
+            else:
+                out[row] = float(function(min(float(time), float(support[-1]))))
+        else:
+            out[row] = float(function(float(time)))
+    return np.clip(out, 0.0, 1.0)
+
+
 def expected_mortality(
     predicted: NDArray[np.float64], grid: NDArray[np.float64]
 ) -> NDArray[np.float64]:
@@ -435,6 +515,7 @@ def d_calibration(
     time: NDArray[np.float64],
     event: NDArray[np.bool_],
     n_bins: int = 10,
+    survival_functions: Sequence[Callable[[float], float]] | None = None,
 ) -> dict[str, float]:
     """Distributional calibration, after Haider et al. (2020).
 
@@ -492,7 +573,10 @@ def d_calibration(
     observed = np.where(beyond, horizon, observed)
     had_event = had_event & ~beyond
 
-    survival_at_observed = _survival_at(predicted, grid, observed)
+    if survival_functions is None:
+        survival_at_observed = _survival_at(predicted, grid, observed)
+    else:
+        survival_at_observed = _survival_from_functions(survival_functions, observed)
     edges = np.linspace(0.0, 1.0, n_bins + 1)
     counts = np.zeros(n_bins, dtype=float)
 
@@ -537,6 +621,7 @@ def antolini_concordance(
     event: NDArray[np.bool_],
     max_events: int = 800,
     seed: int = 0,
+    survival_functions: Sequence[Callable[[float], float]] | None = None,
 ) -> dict[str, float]:
     r"""Time-dependent concordance, after Antolini et al. (2005), Equation 11.
 
@@ -611,7 +696,12 @@ def antolini_concordance(
         if not later.any():
             continue
         event_time = float(observed[subject])
-        at_event = _survival_at_common_time(predicted, grid, event_time, step_like)
+        if survival_functions is None:
+            at_event = _survival_at_common_time(predicted, grid, event_time, step_like)
+        else:
+            at_event = _survival_from_functions(
+                survival_functions, np.full(observed.shape, event_time)
+            )
         own = at_event[subject]
         others = at_event[later]
         comparable += float(others.size)
@@ -643,6 +733,8 @@ def evaluate_all(
     train_event: NDArray[np.bool_],
     eval_time: NDArray[np.float64],
     eval_event: NDArray[np.bool_],
+    prediction_error_times: NDArray[np.float64] | None = None,
+    survival_functions: Sequence[Callable[[float], float]] | None = None,
 ) -> dict[str, Any]:
     """Every metric for one fitted model, on an **independent** evaluation sample.
 
@@ -684,7 +776,14 @@ def evaluate_all(
     )
     results.update(
         prediction_error(
-            predicted, grid, train_time, train_event, eval_time, eval_event, tau
+            predicted,
+            grid,
+            train_time,
+            train_event,
+            eval_time,
+            eval_event,
+            tau,
+            evaluation_times=prediction_error_times,
         )
     )
 
@@ -700,8 +799,24 @@ def evaluate_all(
     # distributions, so the calibration and discrimination measures it reports
     # should be the ones defined for distributions -- not only those defined at
     # a single horizon or on a static risk ranking.
-    results.update(d_calibration(predicted, grid, eval_time, eval_event))
-    results.update(antolini_concordance(predicted, grid, eval_time, eval_event))
+    results.update(
+        d_calibration(
+            predicted,
+            grid,
+            eval_time,
+            eval_event,
+            survival_functions=survival_functions,
+        )
+    )
+    results.update(
+        antolini_concordance(
+            predicted,
+            grid,
+            eval_time,
+            eval_event,
+            survival_functions=survival_functions,
+        )
+    )
 
     # The same ranking taken from survival at tau alone rather than from the
     # whole curve. Under proportional hazards it agrees with the measures above;

--- a/research/discrimination-not-calibration/src/survival_misspec/validation.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/validation.py
@@ -24,10 +24,11 @@ import json
 import platform
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from .config import StudyConfig, content_hash
 
@@ -176,6 +177,9 @@ class ExperimentLock:
             "study_hash": self.study_hash,
             "master_seed": self.master_seed,
             "n_replications": self.n_replications,
+            "scenarios": self.scenarios,
+            "estimators": self.estimators,
+            "metrics": self.metrics,
             "git_commit": self.provenance.get("git_commit"),
             "gen_surv_version": self.provenance.get("gen_surv_version"),
         }
@@ -242,6 +246,22 @@ def read_lock(path: Path | str) -> dict[str, Any]:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
+def _expected_lock_hash(lock: Mapping[str, Any]) -> str:
+    payload = {
+        "paper_id": lock.get("paper_id"),
+        "protocol_version": lock.get("protocol_version"),
+        "study_hash": lock.get("study_hash"),
+        "master_seed": lock.get("master_seed"),
+        "n_replications": lock.get("n_replications"),
+        "scenarios": lock.get("scenarios", ()),
+        "estimators": lock.get("estimators", ()),
+        "metrics": lock.get("metrics", {}),
+        "git_commit": lock.get("provenance", {}).get("git_commit"),
+        "gen_surv_version": lock.get("provenance", {}).get("gen_surv_version"),
+    }
+    return content_hash(payload)
+
+
 def verify_lock(
     path: Path | str, study: StudyConfig, *, strict_commit: bool = True
 ) -> list[str]:
@@ -260,6 +280,14 @@ def verify_lock(
     current = capture_provenance()
     problems: list[str] = []
 
+    stored_hash = lock.get("lock_hash")
+    expected_hash = _expected_lock_hash(lock)
+    if stored_hash != expected_hash:
+        problems.append(
+            f"lock hash changed: lock records {stored_hash or '<missing>'} "
+            f"but its contents hash to {expected_hash}"
+        )
+
     if lock.get("study_hash") != study.hash:
         problems.append(
             f"design changed: lock study_hash={lock.get('study_hash')} "
@@ -271,6 +299,44 @@ def verify_lock(
         problems.append(
             f"master seed changed: {lock.get('master_seed')} -> {study.master_seed}"
         )
+
+    locked_scenarios = lock.get("scenarios", [])
+    if not isinstance(locked_scenarios, list) or not locked_scenarios:
+        problems.append("lock does not contain prepared scenarios")
+    else:
+        current_hashes = {
+            scenario.scenario_id: scenario.hash for scenario in study.scenarios
+        }
+        locked_hashes = {
+            str(record.get("scenario_id")): record.get("scenario_hash")
+            for record in locked_scenarios
+            if isinstance(record, Mapping)
+        }
+        missing = sorted(set(current_hashes) - set(locked_hashes))
+        extra = sorted(set(locked_hashes) - set(current_hashes))
+        if missing:
+            problems.append(f"lock is missing prepared scenarios: {missing[:10]}")
+        if extra:
+            problems.append(f"lock contains unknown prepared scenarios: {extra[:10]}")
+        for scenario_id, current_hash in current_hashes.items():
+            locked_hash = locked_hashes.get(scenario_id)
+            if locked_hash is not None and locked_hash != current_hash:
+                problems.append(
+                    f"scenario {scenario_id} changed: lock scenario_hash="
+                    f"{locked_hash} but current={current_hash}"
+                )
+
+        required_fields = {"params", "tau", "time_grid", "ipcw_time_grid", "feasible"}
+        for record in locked_scenarios:
+            if not isinstance(record, Mapping):
+                problems.append("lock contains a non-mapping prepared scenario")
+                continue
+            missing_fields = sorted(required_fields - set(record))
+            if missing_fields:
+                problems.append(
+                    f"prepared scenario {record.get('scenario_id', '?')} is missing "
+                    f"{missing_fields}"
+                )
 
     locked_provenance = lock.get("provenance", {})
 

--- a/research/discrimination-not-calibration/tests/test_distribution_metrics.py
+++ b/research/discrimination-not-calibration/tests/test_distribution_metrics.py
@@ -20,11 +20,23 @@ from survival_misspec.metrics import (
     antolini_concordance,
     d_calibration,
     prediction_error,
+    truth_recovery,
 )
 
 
 def _exponential_surface(rates: np.ndarray, grid: np.ndarray) -> np.ndarray:
     return np.exp(-np.outer(rates, grid))
+
+
+class _FakeStep:
+    def __init__(self, x: list[float], y: list[float]) -> None:
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+
+    def __call__(self, time: float) -> float:
+        index = int(np.searchsorted(self.x, time, side="left"))
+        index = min(max(index, 0), len(self.y) - 1)
+        return float(self.y[index])
 
 
 def test_d_calibration_does_not_reject_a_correct_model() -> None:
@@ -109,6 +121,27 @@ def test_d_calibration_uses_step_values_not_linear_interpolation() -> None:
 
     # Right-continuous step lookup uses S(1.0) = 0.8. Linear interpolation would
     # use 0.9 and place the event in the top bin.
+    expected = np.zeros(10)
+    expected[8] = 1.0
+    uniform = np.full(10, 0.1)
+    statistic = float(((expected - uniform) ** 2 / uniform).sum())
+    assert outcome["d_calibration_statistic"] == pytest.approx(statistic)
+
+
+def test_d_calibration_can_use_native_step_functions() -> None:
+    grid = np.array([0.0, 1.0, 2.0])
+    predicted = np.array([[1.0, 0.2, 0.2]])
+    observed = np.array([0.5])
+    functions = [_FakeStep([0.0, 0.5, 2.0], [1.0, 0.8, 0.2])]
+
+    outcome = d_calibration(
+        predicted,
+        grid,
+        observed,
+        np.ones(1, dtype=bool),
+        survival_functions=functions,
+    )
+
     expected = np.zeros(10)
     expected[8] = 1.0
     uniform = np.full(10, 0.1)
@@ -216,6 +249,43 @@ def test_antolini_uses_the_next_step_at_event_time() -> None:
     assert outcome["c_index_antolini"] == pytest.approx(1.0)
 
 
+def test_antolini_can_use_native_step_functions() -> None:
+    grid = np.array([0.0, 1.0, 2.0])
+    predicted = np.array(
+        [
+            [1.0, 0.9, 0.9],
+            [1.0, 0.1, 0.1],
+        ]
+    )
+    functions = [
+        _FakeStep([0.0, 0.5, 2.0], [1.0, 0.2, 0.2]),
+        _FakeStep([0.0, 0.5, 2.0], [1.0, 0.8, 0.8]),
+    ]
+
+    outcome = antolini_concordance(
+        predicted,
+        grid,
+        np.array([0.5, 1.5]),
+        np.array([True, True]),
+        survival_functions=functions,
+    )
+
+    assert outcome["antolini_pairs"] == 1
+    assert outcome["c_index_antolini"] == pytest.approx(1.0)
+
+
+def test_truth_recovery_reports_horizon_normalised_squared_loss() -> None:
+    grid = np.linspace(0.0, 2.0, 21)
+    truth = np.tile(np.exp(-grid), (1, 1))
+    predicted = truth + 0.2
+
+    outcome = truth_recovery(predicted, truth, grid, tau=2.0)
+
+    assert outcome["mise"] == pytest.approx(0.08)
+    assert outcome["normalised_mise"] == pytest.approx(0.04)
+    assert outcome["root_mean_integrated_squared_error"] == pytest.approx(0.2)
+
+
 def test_prediction_error_only_labels_a_point_metric_when_it_is_at_tau() -> None:
     grid = np.array([0.0, 0.5, 1.0])
     predicted = np.tile(np.exp(-grid), (20, 1))
@@ -240,6 +310,28 @@ def test_prediction_error_reports_tau_when_tau_is_inside_support() -> None:
     assert outcome["brier_at_tau_time"] == pytest.approx(1.0)
     assert outcome["auc_at_tau_time"] == pytest.approx(1.0)
     assert np.isfinite(outcome["brier_at_tau"])
+
+
+def test_prediction_error_does_not_shorten_a_fixed_interval() -> None:
+    grid = np.array([0.0, 0.5, 1.0])
+    predicted = np.tile(np.exp(-grid), (20, 1))
+    time = np.linspace(0.1, 0.8, 20)
+    event = np.ones(20, dtype=bool)
+
+    outcome = prediction_error(
+        predicted,
+        grid,
+        time,
+        event,
+        time,
+        event,
+        tau=1.0,
+        evaluation_times=np.array([0.5, 1.0]),
+    )
+
+    assert np.isnan(outcome["integrated_brier_score"])
+    assert np.isnan(outcome["auc_mean"])
+    assert "fixed IPCW interval" in outcome["prediction_error_note"]
 
 
 def test_antolini_handles_a_sample_with_no_events() -> None:

--- a/research/discrimination-not-calibration/tests/test_pipeline.py
+++ b/research/discrimination-not-calibration/tests/test_pipeline.py
@@ -21,8 +21,10 @@ import pytest
 from survival_misspec.aggregation import (
     adequacy_region_from_pairs,
     aggregate,
+    compact_raw,
     completed_cells,
     failure_rates,
+    headline_metric_gap,
     mcse,
     paired_differences,
     replications_for_precision,
@@ -317,6 +319,7 @@ def _raw() -> pd.DataFrame:
                 "fitted": True,
                 "scored": True,
                 "mise": 0.10,
+                "root_mean_integrated_squared_error": 0.20,
                 "dgp": "cphm",
             },
             {
@@ -326,6 +329,7 @@ def _raw() -> pd.DataFrame:
                 "fitted": True,
                 "scored": True,
                 "mise": 0.20,
+                "root_mean_integrated_squared_error": 0.30,
                 "dgp": "cphm",
             },
             {
@@ -335,6 +339,7 @@ def _raw() -> pd.DataFrame:
                 "fitted": False,
                 "scored": False,
                 "mise": np.nan,
+                "root_mean_integrated_squared_error": np.nan,
                 "dgp": "cphm",
             },
         ]
@@ -449,6 +454,26 @@ def test_completed_cells_supports_resumption(tmp_path) -> None:
     assert len(done) == 3
 
 
+def test_completed_cells_requires_the_matching_lock_for_production_resume(
+    tmp_path,
+) -> None:
+    path = tmp_path / "raw.parquet"
+    rows = _raw().assign(lock_hash="abc").to_dict("records")
+    write_raw(rows, path)
+
+    assert len(completed_cells(path, lock_hash="abc")) == 3
+    with pytest.raises(ValueError, match="expected xyz"):
+        completed_cells(path, lock_hash="xyz")
+
+
+def test_completed_cells_refuses_unlocked_rows_for_production_resume(tmp_path) -> None:
+    path = tmp_path / "raw.parquet"
+    write_raw(_raw().to_dict("records"), path)
+
+    with pytest.raises(ValueError, match="without lock_hash"):
+        completed_cells(path, lock_hash="abc")
+
+
 def test_write_raw_appends_parquet_shards_without_rewriting(tmp_path) -> None:
     path = tmp_path / "raw.parquet"
 
@@ -472,6 +497,33 @@ def test_write_raw_appends_parquet_shards_without_rewriting(tmp_path) -> None:
     done = completed_cells(path)
     assert ("s", "rsf", 0) in done
     assert len(done) == 4
+
+
+def test_compact_raw_writes_one_deterministic_file(tmp_path) -> None:
+    path = tmp_path / "raw.parquet"
+    write_raw(_raw().iloc[[1]].to_dict("records"), path)
+    write_raw(_raw().iloc[[0]].to_dict("records"), path)
+
+    compacted = compact_raw(path)
+    frame = pd.read_parquet(compacted)
+
+    assert compacted.name == "raw.parquet.compact.parquet"
+    assert frame["replication_id"].tolist() == [0, 1]
+
+
+def test_headline_metric_gap_operationalises_the_primary_claim() -> None:
+    raw = pd.DataFrame(
+        {
+            "scored": [True, True, True, True],
+            "c_index_harrell": [0.6, 0.61, 0.7, 0.71],
+            "root_mean_integrated_squared_error": [0.05, 0.20, 0.04, 0.30],
+        }
+    )
+
+    headline = headline_metric_gap(raw, bins=2, quantile=0.9)
+
+    assert list(headline["metric"]) == ["c_index_harrell", "c_index_harrell"]
+    assert headline["loss_quantile"].max() == pytest.approx(0.274)
 
 
 # ---------------------------------------------------------------------------
@@ -513,6 +565,33 @@ def test_tau_excludes_cured_subjects() -> None:
         f"tau={prepared.tau} looks like the cured sentinel (max_time * 100), "
         "not a failure-time quantile"
     )
+    assert len(prepared.ipcw_time_grid) >= 2
+
+
+def test_prepared_scenario_rehydrates_from_lock_record() -> None:
+    from survival_misspec.config import MetricsConfig, ScenarioConfig
+    from survival_misspec.experiments import (
+        prepare_scenario,
+        prepared_scenario_from_record,
+    )
+
+    scenario = ScenarioConfig(
+        scenario_id="locked",
+        dgp="cphm",
+        n=100,
+        target_censoring=0.3,
+        effect_size=0.5,
+        params={"beta": 0.5, "covariate_range": 2.0, "model_cens": "uniform"},
+    )
+    prepared = prepare_scenario(
+        scenario, MetricsConfig(0.8, 21, (0.5,), ("mise",)), calibration_n=1000
+    )
+    loaded = prepared_scenario_from_record(scenario, prepared.as_record())
+
+    assert loaded.params == prepared.params
+    assert loaded.tau == prepared.tau
+    assert loaded.time_grid == prepared.time_grid
+    assert loaded.ipcw_time_grid == prepared.ipcw_time_grid
 
 
 def test_cells_are_independent_of_the_order_they_are_run_in() -> None:

--- a/research/discrimination-not-calibration/tests/test_provenance.py
+++ b/research/discrimination-not-calibration/tests/test_provenance.py
@@ -41,7 +41,17 @@ def _write(tmp_path, study: StudyConfig):
     return write_lock(
         tmp_path / "experiment_lock.json",
         study,
-        [{"scenario_id": "s1", "tau": 1.0}],
+        [
+            {
+                "scenario_id": "s1",
+                "scenario_hash": study.scenarios[0].hash,
+                "params": {"beta": 0.5, "cens_par": 2.0},
+                "tau": 1.0,
+                "time_grid": [0.0, 0.5, 1.0],
+                "ipcw_time_grid": [0.5, 1.0],
+                "feasible": True,
+            }
+        ],
         protocol_version="0.1.0",
         allow_dirty_tree=True,
     )
@@ -163,3 +173,57 @@ def test_lock_hash_distinguishes_experiments(tmp_path) -> None:
     first = _write(tmp_path / "a", _study())
     second = _write(tmp_path / "b", _study(master_seed=2))
     assert first.lock_hash != second.lock_hash
+
+
+def test_lock_hash_includes_prepared_scenarios(tmp_path) -> None:
+    study = _study()
+    first = write_lock(
+        tmp_path / "a" / "lock.json",
+        study,
+        [
+            {
+                "scenario_id": "s1",
+                "scenario_hash": study.scenarios[0].hash,
+                "params": {"beta": 0.5, "cens_par": 2.0},
+                "tau": 1.0,
+                "time_grid": [0.0, 0.5, 1.0],
+                "ipcw_time_grid": [0.5, 1.0],
+                "feasible": True,
+            }
+        ],
+        protocol_version="0.1.0",
+        allow_dirty_tree=True,
+    )
+    second = write_lock(
+        tmp_path / "b" / "lock.json",
+        study,
+        [
+            {
+                "scenario_id": "s1",
+                "scenario_hash": study.scenarios[0].hash,
+                "params": {"beta": 0.5, "cens_par": 3.0},
+                "tau": 1.2,
+                "time_grid": [0.0, 0.6, 1.2],
+                "ipcw_time_grid": [0.6, 1.2],
+                "feasible": True,
+            }
+        ],
+        protocol_version="0.1.0",
+        allow_dirty_tree=True,
+    )
+
+    assert first.lock_hash != second.lock_hash
+
+
+def test_lock_verification_requires_prepared_scenarios(tmp_path) -> None:
+    study = _study()
+    path = tmp_path / "experiment_lock.json"
+    _write(tmp_path, study)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["scenarios"][0].pop("time_grid")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    problems = verify_lock(path, study, strict_commit=False)
+
+    assert any("missing ['time_grid']" in problem for problem in problems)


### PR DESCRIPTION
## Summary
- lock prepared scenarios into the experiment identity and require matching lock hashes for production resume
- add normalized truth-loss outputs, fixed IPCW grids, exact native step-function scoring, raw compaction, freeze and grid-convergence scripts
- update generated tables/figures/protocol language and the mixture-cure null effect definition

## Tests
- poetry run python -m pytest research\\discrimination-not-calibration\\tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pre-freeze integrity gaps so the production experiment can be frozen once, resumed after interruption, and compared across mechanisms on a single scale.

**Experiment freeze**
- `freeze_experiment.py` prepares every scenario once and writes `protocol/experiment_lock.json` with scenario hashes and the prepared grids.
- Production runs load prepared scenarios from the lock and stamp each row with the lock hash; resuming refuses rows whose hash is missing or different.
- `check_grid_convergence.py` reruns matched cells at 51, 201, and 801 time points so the freeze documents whether the 51-point production grid is adequate.

**Metrics and scoring**
- Adds `normalised_mise` and `root_mean_integrated_squared_error` (RMISE) to the config; figures, tables, hypotheses, and the preregistration now use RMISE instead of raw MISE.
- Brier score and time-dependent AUC use a fixed scenario-level IPCW grid; a replication that cannot support it marks them unavailable instead of shortening the grid.
- D-calibration and Antolini concordance now evaluate native scikit-survival step functions rather than interpolating the coarse evaluation grid.
- Adds `headline.parquet` (90th percentile RMISE within C-index bins) and a `--compact` flag for one deterministic raw Parquet file; also updates the `mixture_cure` cure-effect parameter and the ICML 2026 citation.

<sup>Written for commit 84b126120a0cec708c8cc44a456712cc46cab339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

