### PR TITLE
Add final research analysis closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,13 +66,16 @@ site/
 # this.
 papers/
 
-# Pilot artefacts from the research studies: exploratory, regenerable from the
-# config and seeds, and never to be confused with frozen production results.
+# Research artifacts: generated from committed config, seeds and lock files,
+# and never to be confused with source.
 # scripts/run_pilot.py refuses to read a file containing production rows for
-# the same reason. Production results are tracked; these are not.
+# the same reason.
 research/*/results/raw/pilot.parquet
 research/*/results/raw/production.parquet
+research/*/results/raw/production.parquet.compact.parquet
 research/*/results/raw/*.parts/
+research/*/results/grid_convergence.parquet
+research/*/results/ipcw_availability.parquet
 research/*/results/processed/
 research/*/results/figures/
 research/*/protocol/experiment_lock.json

--- a/research/discrimination-not-calibration/README.md
+++ b/research/discrimination-not-calibration/README.md
@@ -65,10 +65,14 @@ without matching it:
 ```bash
 python scripts/make_config.py --production
 python scripts/freeze_experiment.py --out protocol/experiment_lock.json
+python scripts/audit_ipcw_availability.py
+python scripts/check_grid_convergence.py
 python scripts/run_simulation.py \
     --out results/raw/production.parquet \
     --lock protocol/experiment_lock.json \
     --compact
+python scripts/aggregate_results.py --raw results/raw/production.parquet
+python scripts/analyze_hypotheses.py
 ```
 
 `protocol/experiment_lock.json` is a local execution artifact, not a committed

--- a/research/discrimination-not-calibration/literature/positioning.md
+++ b/research/discrimination-not-calibration/literature/positioning.md
@@ -11,7 +11,6 @@
 | Birolo et al. (2025) | **yes** — Abstract, Sections 3.1–3.3 |
 | Sonabend et al. (2022) | **yes** — Abstract, Sections 1–3.1 |
 | Austin et al. (2020) | not yet |
-| Sonabend et al. (2022) | not yet |
 | Burk et al. (2026) | not yet |
 | Cox (1972), Grambsch & Therneau (1994), | |
 | Schemper et al. (2009), Harrell et al. (1982), | deposited, not yet read |

--- a/research/discrimination-not-calibration/paper/sections/related_work.tex
+++ b/research/discrimination-not-calibration/paper/sections/related_work.tex
@@ -1,9 +1,8 @@
 \section{Related work}
 \label{sec:related}
 
-% NOT WRITTEN. None of the cited papers has been read: the PDFs are not in the
-% repository-local papers/ directory. Nothing here may be drafted from the
-% bibliography entries alone.
+% NOT WRITTEN. Draft only from the source-specific reading notes in
+% ../literature/positioning.md; bibliography metadata alone is not evidence.
 %
 % When written, this section must do three things:
 %

--- a/research/discrimination-not-calibration/protocol/estimands.md
+++ b/research/discrimination-not-calibration/protocol/estimands.md
@@ -210,9 +210,11 @@ horizon $\tau$ and the loss. What counts as an adequate approximation is an
 application's judgement, not a statistical constant.
 
 The headline quantity is the 90th percentile of RMISE conditional on bins of a
-conventional metric, primarily Harrell's C-index. This reports the upper tail of
-truth-error compatible with similar conventional metric values, which is the
-measurement question of the study.
+conventional metric, primarily Harrell's C-index, computed over
+scenario-estimator cell means. This reports the upper tail of truth-error
+compatible with similar conventional metric values, which is the measurement
+question of the study. Its uncertainty is propagated from the cell MCSEs with
+fixed-bin parametric bootstrap draws.
 
 ---
 

--- a/research/discrimination-not-calibration/protocol/preregistration.md
+++ b/research/discrimination-not-calibration/protocol/preregistration.md
@@ -181,7 +181,27 @@ application.
 The headline number is the 90th percentile of RMISE conditional on bins of a
 conventional metric, primarily Harrell's C-index. This answers the operational
 question "how large can truth-error be among rows with similar conventional
-metric values?" without turning a correlation coefficient into the claim.
+metric values?" without turning a correlation coefficient into the claim. It is
+computed over scenario-estimator cell means, and its Monte Carlo uncertainty is
+propagated from the cell MCSEs with fixed-bin parametric bootstrap draws.
+
+The executable hypothesis analysis is `scripts/analyze_hypotheses.py`, which
+writes `results/processed/hypotheses.parquet` and `.json`. H2's correctly
+specified reference is `cox_ph` for `cphm`, `aft_weibull` and
+`piecewise_exponential`; no exact comparator is claimed for `aft_ln`,
+`aft_log_logistic` or `mixture_cure`. H3's proportional-hazards estimators are
+`cox_ph` and `gradient_boosted`; its structural-violation DGPs are `aft_ln`,
+`aft_log_logistic` and `mixture_cure`, compared with the PH/baseline group
+`cphm`, `aft_weibull` and `piecewise_exponential` on common
+$(n,\text{censoring},\beta,\text{estimator})$ support. H4 is paired on common
+$(\text{DGP},n,\beta,\text{estimator})$ support for 10% versus 70% censoring;
+`mixture_cure` drops out of that contrast because it has no 10% support.
+
+Before freezing, `scripts/audit_ipcw_availability.py` must pass with a minimum
+availability rate of 0.95 among feasible scenarios. `scripts/check_grid_convergence.py`
+must pass with
+$|\mathrm{RMISE}_{51}-\mathrm{RMISE}_{801}| \le 0.005$, half a percentage point
+on the survival-probability scale, for the audited matched cells.
 
 No inferential test is used to declare an estimator superior. Conclusions are
 conditional on the mechanisms studied, and no claim of general superiority will

--- a/research/discrimination-not-calibration/scripts/aggregate_results.py
+++ b/research/discrimination-not-calibration/scripts/aggregate_results.py
@@ -21,8 +21,8 @@ Writes to ``results/processed/``:
     epsilon, for the adequacy region, with paired MCSEs.
 
 ``headline.parquet``
-    Conditional upper-tail normalised truth loss among rows with comparable
-    conventional metric values.
+    Conditional upper-tail normalised truth loss among cells with comparable
+    conventional metric values, with MCSEs propagated from cell means.
 
 Nothing here decides anything. It aggregates and reports uncertainty; the
 interpretation belongs in the paper, conditional on the DGPs studied.
@@ -109,7 +109,7 @@ def main() -> int:
         print(f"adequacy        {len(adequacy)} rows over {len(EPSILONS)} epsilons")
 
     try:
-        headline = headline_metric_gap(raw)
+        headline = headline_metric_gap(summary)
     except ValueError as error:
         print(f"headline        skipped: {error}")
     else:

--- a/research/discrimination-not-calibration/scripts/analyze_hypotheses.py
+++ b/research/discrimination-not-calibration/scripts/analyze_hypotheses.py
@@ -1,0 +1,51 @@
+"""Compute the preregistered H1--H4 estimands from processed results.
+
+    python scripts/analyze_hypotheses.py --processed results/processed
+
+Writes ``hypotheses.parquet`` and ``hypotheses.json``. The manuscript and
+tables should consume those artifacts rather than recomputing hypothesis
+quantities ad hoc.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from survival_misspec.hypotheses import analyse_hypotheses  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--processed", default=str(HERE.parent / "results" / "processed")
+    )
+    arguments = parser.parse_args()
+
+    processed = Path(arguments.processed)
+    summary_path = processed / "summary.parquet"
+    if not summary_path.exists():
+        print(f"no summary at {summary_path}; run aggregate_results.py first")
+        return 1
+
+    hypotheses = analyse_hypotheses(pd.read_parquet(summary_path))
+    parquet_path = processed / "hypotheses.parquet"
+    json_path = processed / "hypotheses.json"
+    hypotheses.to_parquet(parquet_path, index=False)
+    json_path.write_text(
+        json.dumps(hypotheses.to_dict("records"), indent=2), encoding="utf-8"
+    )
+    print(f"hypotheses     {len(hypotheses)} rows -> {parquet_path}")
+    print(f"json           {json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/discrimination-not-calibration/scripts/audit_ipcw_availability.py
+++ b/research/discrimination-not-calibration/scripts/audit_ipcw_availability.py
@@ -1,0 +1,150 @@
+"""Audit whether production replications support the frozen IPCW grids.
+
+    python scripts/audit_ipcw_availability.py --config config --out results/ipcw_availability.parquet
+
+IBS and mean AUC are undefined when the prespecified IPCW grid falls outside a
+replication's observed follow-up support. This pre-freeze audit estimates that
+availability rate without fitting any models, because the support condition
+depends only on the simulated train/evaluation outcome times.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent / "src"))
+
+from survival_misspec.config import load_study  # noqa: E402
+from survival_misspec.experiments import prepare_scenario  # noqa: E402
+from survival_misspec.simulation import draw_replicate  # noqa: E402
+
+
+def _supported(grid: np.ndarray, train_time: np.ndarray, eval_time: np.ndarray) -> bool:
+    if grid.size < 2:
+        return False
+    lower = max(float(np.min(train_time)), float(np.min(eval_time)))
+    upper = min(float(np.max(train_time)), float(np.max(eval_time)))
+    return bool(np.all((grid > lower) & (grid < upper)))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default=str(HERE.parent / "config"))
+    parser.add_argument(
+        "--out", default=str(HERE.parent / "results" / "ipcw_availability.parquet")
+    )
+    parser.add_argument("--calibration-n", type=int, default=20000)
+    parser.add_argument("--replications", type=int, default=50)
+    parser.add_argument("--max-scenarios", type=int, default=None)
+    parser.add_argument(
+        "--minimum-availability",
+        type=float,
+        default=0.95,
+        help="minimum acceptable scenario-level availability rate",
+    )
+    arguments = parser.parse_args()
+
+    study = load_study(arguments.config)
+    rows: list[dict[str, object]] = []
+    scenarios = list(study.scenarios)
+    if arguments.max_scenarios is not None:
+        scenarios = scenarios[: arguments.max_scenarios]
+
+    for scenario in scenarios:
+        prepared = prepare_scenario(
+            scenario, study.metrics, calibration_n=arguments.calibration_n
+        )
+        if not prepared.feasible:
+            rows.append(
+                {
+                    "scenario_id": scenario.scenario_id,
+                    "dgp": scenario.dgp,
+                    "n": scenario.n,
+                    "target_censoring": scenario.target_censoring,
+                    "effect_size": scenario.effect_size,
+                    "feasible": False,
+                    "availability": float("nan"),
+                    "supported": 0,
+                    "attempted": 0,
+                    "passes": False,
+                    "reason": prepared.reason,
+                }
+            )
+            continue
+
+        grid = np.asarray(prepared.ipcw_time_grid, dtype=float)
+        supported = 0
+        for replication_id in range(arguments.replications):
+            train = draw_replicate(
+                scenario.dgp,
+                prepared.params,
+                scenario.n,
+                scenario.scenario_id,
+                replication_id,
+                study.master_seed,
+                stream="train",
+            )
+            evaluation = draw_replicate(
+                scenario.dgp,
+                prepared.params,
+                scenario.n,
+                scenario.scenario_id,
+                replication_id,
+                study.master_seed,
+                stream="eval",
+            )
+            supported += int(
+                _supported(grid, train.observed_time, evaluation.observed_time)
+            )
+
+        availability = supported / arguments.replications
+        rows.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "dgp": scenario.dgp,
+                "n": scenario.n,
+                "target_censoring": scenario.target_censoring,
+                "effect_size": scenario.effect_size,
+                "feasible": True,
+                "availability": availability,
+                "supported": supported,
+                "attempted": arguments.replications,
+                "passes": availability >= arguments.minimum_availability,
+                "reason": "",
+            }
+        )
+
+    frame = pd.DataFrame.from_records(rows)
+    out = Path(arguments.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_parquet(out, index=False)
+    feasible = frame[frame["feasible"]]
+    failures = feasible[~feasible["passes"]]
+    print(f"written        {len(frame)} scenarios -> {out}")
+    if not feasible.empty:
+        print(f"minimum        {feasible['availability'].min():.3f}")
+    if failures.empty:
+        print(
+            f"criterion      pass: all feasible scenarios >= {arguments.minimum_availability:.2f}"
+        )
+        return 0
+
+    print(f"criterion      fail: {len(failures)} feasible scenarios below threshold")
+    print(
+        failures.sort_values("availability")[
+            ["scenario_id", "availability", "n", "target_censoring", "effect_size"]
+        ]
+        .head(20)
+        .to_string(index=False)
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/discrimination-not-calibration/scripts/check_grid_convergence.py
+++ b/research/discrimination-not-calibration/scripts/check_grid_convergence.py
@@ -3,8 +3,9 @@
     python scripts/check_grid_convergence.py --config config --out results/grid_convergence.parquet
 
 The production config uses 51 time points. This diagnostic reruns matched cells
-at 51, 201 and 801 points and reports the difference from the 801-point value,
-so the freeze can document whether the production grid is adequate.
+at 51, 201 and 801 points and compares each with the 801-point value. The
+default acceptance threshold is 0.005 RMISE, half a percentage point on the
+survival-probability scale.
 """
 
 from __future__ import annotations
@@ -31,9 +32,15 @@ def main() -> int:
     )
     parser.add_argument("--grid-points", type=int, nargs="+", default=[51, 201, 801])
     parser.add_argument("--calibration-n", type=int, default=20000)
-    parser.add_argument("--replications", type=int, default=1)
+    parser.add_argument("--replications", type=int, default=3)
     parser.add_argument("--max-scenarios", type=int, default=None)
     parser.add_argument("--estimators", nargs="*", default=None)
+    parser.add_argument(
+        "--rmise-epsilon",
+        type=float,
+        default=0.005,
+        help="maximum acceptable absolute RMISE difference versus the finest grid",
+    )
     arguments = parser.parse_args()
 
     study = load_study(arguments.config)
@@ -121,7 +128,18 @@ def main() -> int:
         .max()
     )
     print(summary.to_string())
-    return 0
+    maximum = float(summary["rmise_absolute_difference"].max())
+    if maximum <= arguments.rmise_epsilon:
+        print(
+            f"criterion pass: max |RMISE - RMISE_{reference_grid}| "
+            f"{maximum:.6f} <= {arguments.rmise_epsilon:.6f}"
+        )
+        return 0
+    print(
+        f"criterion fail: max |RMISE - RMISE_{reference_grid}| "
+        f"{maximum:.6f} > {arguments.rmise_epsilon:.6f}"
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/research/discrimination-not-calibration/scripts/make_figures.py
+++ b/research/discrimination-not-calibration/scripts/make_figures.py
@@ -164,9 +164,9 @@ def figure_discrimination_vs_truth(
 
     finite = summary[["c_index_harrell_mean", TRUTH_LOSS_MEAN]].dropna()
     if len(finite) > 2:
-        correlation = finite.corr().iloc[0, 1]
+        correlation = finite.corr(method="spearman").iloc[0, 1]
         axis.annotate(
-            f"r = {correlation:+.3f}",
+            f"Spearman rho = {correlation:+.3f}",
             xy=(0.03, 0.03),
             xycoords="axes fraction",
             fontsize=8,

--- a/research/discrimination-not-calibration/scripts/make_tables.py
+++ b/research/discrimination-not-calibration/scripts/make_tables.py
@@ -8,8 +8,8 @@ manuscript by hand.** Each file carries a generated-by header, and
 which is what stops a number being pasted in and then quietly diverging from
 the results it came from.
 
-Tables 1 and 2 describe the design and can be produced before any run. Tables
-3 to 5 need results and are skipped with a message when they are absent, rather
+Tables 1 and 2 describe the design and can be produced before any run. Later
+tables need results and are skipped with a message when they are absent, rather
 than emitting an empty table that looks finished.
 """
 
@@ -321,6 +321,37 @@ def table_failures(failures: pd.DataFrame, out: Path) -> None:
     )
 
 
+def table_hypotheses(hypotheses: pd.DataFrame, out: Path) -> None:
+    """The executable H1--H4 definitions and their support status."""
+    if hypotheses.empty:
+        print("  table6: skipped, no hypotheses table")
+        return
+
+    body = [
+        r"\begin{table}[t]",
+        r"\centering\small",
+        r"\caption{Preregistered hypothesis estimands, computed by "
+        r"\texttt{scripts/analyze\_hypotheses.py}.}",
+        r"\label{tab:hypotheses}",
+        r"\begin{tabular}{llrl}",
+        r"\toprule",
+        r"Hypothesis & Estimand & Estimate & Criterion \\",
+        r"\midrule",
+    ]
+    for row in hypotheses.itertuples():
+        decision = "supports" if row.supports_hypothesis else "does not support"
+        body.append(
+            f"{_escape(str(row.hypothesis))} & {_escape(str(row.estimand))} & "
+            f"{row.estimate:.4f} & {_escape(str(row.criterion))}; {decision} \\\\"
+        )
+    body += [r"\bottomrule", r"\end{tabular}", r"\end{table}", ""]
+    _write(
+        out / "table6_hypotheses.tex",
+        "\n".join(body),
+        "results/processed/hypotheses.parquet",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", default=str(HERE.parent / "config"))
@@ -349,11 +380,17 @@ def main() -> int:
         if (processed / "failures.parquet").exists()
         else pd.DataFrame()
     )
+    hypotheses = (
+        pd.read_parquet(processed / "hypotheses.parquet")
+        if (processed / "hypotheses.parquet").exists()
+        else pd.DataFrame()
+    )
 
     print("result tables:")
     table_main_results(summary, out)
     table_parameter_recovery(summary, out)
     table_failures(failures, out)
+    table_hypotheses(hypotheses, out)
 
     print(f"\nwritten to {out}")
     return 0

--- a/research/discrimination-not-calibration/scripts/reproduce.py
+++ b/research/discrimination-not-calibration/scripts/reproduce.py
@@ -92,15 +92,19 @@ def main() -> int:
         "3. Aggregate, with Monte Carlo standard errors",
         [python, "scripts/aggregate_results.py", "--raw", raw],
     )
-    step("4. Generate the tables", [python, "scripts/make_tables.py"])
     step(
-        "5. Generate the figures",
+        "4. Analyse the preregistered hypotheses",
+        [python, "scripts/analyze_hypotheses.py"],
+    )
+    step("5. Generate the tables", [python, "scripts/make_tables.py"])
+    step(
+        "6. Generate the figures",
         [python, "scripts/make_figures.py", "--raw", raw],
     )
 
     if arguments.pilot:
         step(
-            "6. Report the pilot design analysis",
+            "7. Report the pilot design analysis",
             [python, "scripts/run_pilot.py", "--raw", raw],
         )
 

--- a/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
@@ -236,43 +236,61 @@ def paired_differences(
 
 
 def headline_metric_gap(
-    raw: pd.DataFrame,
+    summary: pd.DataFrame,
     *,
-    conventional_metric: str = "c_index_harrell",
-    loss: str = "root_mean_integrated_squared_error",
+    conventional_metric: str = "c_index_harrell_mean",
+    loss: str = "root_mean_integrated_squared_error_mean",
     bins: int = 10,
     quantile: float = 0.90,
+    uncertainty_draws: int = 1000,
+    seed: int = 20260829,
 ) -> pd.DataFrame:
     """Conditional upper-tail truth loss at comparable conventional metrics.
 
     This is the operational headline for "how much truth-error is consistent
-    with a conventional metric": bin cells by the conventional metric and
-    report a high conditional quantile of the normalised truth loss.
+    with a conventional metric": bin scenario-estimator cell means by the
+    conventional metric and report a high conditional quantile of the
+    normalised truth loss. Uncertainty is the Monte Carlo uncertainty induced by
+    the cell mean estimates, propagated by a fixed-bin parametric bootstrap.
     """
-    needed = {conventional_metric, loss, "scored"}
-    missing = sorted(needed - set(raw.columns))
+    needed = {conventional_metric, loss}
+    missing = sorted(needed - set(summary.columns))
     if missing:
         raise ValueError(f"headline table missing columns: {missing}")
 
-    scored = raw[raw["scored"].fillna(False)].copy()
-    scored[conventional_metric] = pd.to_numeric(
-        scored[conventional_metric], errors="coerce"
+    frame = summary.copy()
+    frame[conventional_metric] = pd.to_numeric(
+        frame[conventional_metric], errors="coerce"
     )
-    scored[loss] = pd.to_numeric(scored[loss], errors="coerce")
-    scored = scored.dropna(subset=[conventional_metric, loss])
-    if scored.empty:
+    frame[loss] = pd.to_numeric(frame[loss], errors="coerce")
+    frame = frame.dropna(subset=[conventional_metric, loss])
+    if frame.empty:
         return pd.DataFrame()
 
     try:
-        scored["_metric_bin"] = pd.qcut(
-            scored[conventional_metric], q=bins, duplicates="drop"
+        frame["_metric_bin"] = pd.qcut(
+            frame[conventional_metric], q=bins, duplicates="drop"
         )
     except ValueError:
-        scored["_metric_bin"] = pd.cut(scored[conventional_metric], bins=bins)
+        frame["_metric_bin"] = pd.cut(frame[conventional_metric], bins=bins)
+
+    loss_mcse_column = loss.removesuffix("_mean") + "_mcse"
+    rng = np.random.default_rng(seed)
 
     records: list[dict[str, object]] = []
-    for interval, block in scored.groupby("_metric_bin", observed=True):
+    for interval, block in frame.groupby("_metric_bin", observed=True):
         values = block[loss].to_numpy(dtype=float)
+        loss_mcse = (
+            pd.to_numeric(block[loss_mcse_column], errors="coerce")
+            .fillna(0.0)
+            .to_numpy(dtype=float)
+            if loss_mcse_column in block.columns
+            else np.zeros_like(values)
+        )
+        draws = np.empty(uncertainty_draws, dtype=float)
+        for draw in range(uncertainty_draws):
+            sampled = rng.normal(values, loss_mcse)
+            draws[draw] = float(np.quantile(sampled, quantile))
         records.append(
             {
                 "metric": conventional_metric,
@@ -282,6 +300,9 @@ def headline_metric_gap(
                 "metric_min": float(block[conventional_metric].min()),
                 "metric_max": float(block[conventional_metric].max()),
                 "loss_quantile": float(np.quantile(values, quantile)),
+                "loss_quantile_mcse": mcse(draws),
+                "loss_quantile_ci_low": float(np.quantile(draws, 0.025)),
+                "loss_quantile_ci_high": float(np.quantile(draws, 0.975)),
                 "loss_median": float(np.median(values)),
                 "n": int(values.size),
             }

--- a/research/discrimination-not-calibration/src/survival_misspec/hypotheses.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/hypotheses.py
@@ -1,0 +1,219 @@
+"""Executable definitions of the preregistered H1--H4 estimands."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "CORRECTLY_SPECIFIED_REFERENCE",
+    "PROPORTIONAL_HAZARDS_ESTIMATORS",
+    "STRUCTURAL_VIOLATION_DGPS",
+    "PH_OR_BASELINE_DGPS",
+    "analyse_hypotheses",
+]
+
+CORRECTLY_SPECIFIED_REFERENCE = {
+    "cphm": "cox_ph",
+    "aft_weibull": "cox_ph",
+    "piecewise_exponential": "cox_ph",
+}
+PROPORTIONAL_HAZARDS_ESTIMATORS = ("cox_ph", "gradient_boosted")
+STRUCTURAL_VIOLATION_DGPS = ("aft_ln", "aft_log_logistic", "mixture_cure")
+PH_OR_BASELINE_DGPS = ("cphm", "aft_weibull", "piecewise_exponential")
+
+RMISE = "root_mean_integrated_squared_error_mean"
+NMISE = "normalised_mise_mean"
+C_INDEX = "c_index_harrell_mean"
+
+
+def _finite(frame: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
+    out = frame.copy()
+    for column in columns:
+        out[column] = pd.to_numeric(out[column], errors="coerce")
+    return out.dropna(subset=list(columns))
+
+
+def _record(
+    hypothesis: str,
+    estimand: str,
+    estimate: float,
+    *,
+    supports: bool,
+    n: int,
+    criterion: str,
+    note: str = "",
+) -> dict[str, object]:
+    return {
+        "hypothesis": hypothesis,
+        "estimand": estimand,
+        "estimate": float(estimate) if np.isfinite(estimate) else float("nan"),
+        "supports_hypothesis": bool(supports),
+        "n": int(n),
+        "criterion": criterion,
+        "note": note,
+    }
+
+
+def _h1(summary: pd.DataFrame) -> dict[str, object]:
+    frame = _finite(summary, [C_INDEX, RMISE])
+    if "misspecification" in frame.columns:
+        frame = frame[
+            ~frame["misspecification"].astype(str).str.startswith("none", na=False)
+        ]
+    estimate = float(frame[C_INDEX].corr(frame[RMISE], method="spearman"))
+    return _record(
+        "H1",
+        "spearman_c_index_rmise_misspecified_cells",
+        estimate,
+        supports=abs(estimate) < 0.30,
+        n=len(frame),
+        criterion="abs(estimate) < 0.30",
+        note="computed on scenario-estimator cell means for misspecified scenarios",
+    )
+
+
+def _h2(summary: pd.DataFrame) -> dict[str, object]:
+    frame = _finite(summary, [C_INDEX, NMISE])
+    records = []
+    for dgp, reference in CORRECTLY_SPECIFIED_REFERENCE.items():
+        block = frame[frame["dgp"] == dgp]
+        refs = block[block["estimator_id"] == reference][
+            ["scenario_id", C_INDEX, NMISE]
+        ].rename(
+            columns={
+                C_INDEX: "reference_c_index",
+                NMISE: "reference_nmise",
+            }
+        )
+        candidates = block[block["estimator_id"] != reference]
+        joined = candidates.merge(refs, on="scenario_id", how="inner")
+        joined = joined[joined["reference_nmise"] > 0]
+        if not joined.empty:
+            joined = joined.assign(
+                nmise_ratio=joined[NMISE] / joined["reference_nmise"]
+            )
+            records.append(joined)
+
+    if not records:
+        return _record(
+            "H2",
+            "max_nmise_ratio_at_or_above_correct_reference_c_index",
+            float("nan"),
+            supports=False,
+            n=0,
+            criterion="estimate >= 10",
+            note="no DGP had a mapped correctly specified reference estimator",
+        )
+
+    comparisons = pd.concat(records, ignore_index=True)
+    admissible = comparisons[comparisons[C_INDEX] >= comparisons["reference_c_index"]]
+    estimate = (
+        float(admissible["nmise_ratio"].max()) if not admissible.empty else float("nan")
+    )
+    return _record(
+        "H2",
+        "max_nmise_ratio_at_or_above_correct_reference_c_index",
+        estimate,
+        supports=np.isfinite(estimate) and estimate >= 10.0,
+        n=len(admissible),
+        criterion="estimate >= 10",
+        note=(
+            "correct references are "
+            + ", ".join(
+                f"{dgp}:{estimator}"
+                for dgp, estimator in CORRECTLY_SPECIFIED_REFERENCE.items()
+            )
+        ),
+    )
+
+
+def _h3(summary: pd.DataFrame) -> dict[str, object]:
+    frame = _finite(summary, [RMISE])
+    frame = frame[frame["estimator_id"].isin(PROPORTIONAL_HAZARDS_ESTIMATORS)]
+    frame = frame[
+        frame["dgp"].isin(STRUCTURAL_VIOLATION_DGPS)
+        | frame["dgp"].isin(PH_OR_BASELINE_DGPS)
+    ].copy()
+    frame["group"] = np.where(
+        frame["dgp"].isin(STRUCTURAL_VIOLATION_DGPS), "structural", "ph_or_baseline"
+    )
+
+    key = ["n", "target_censoring", "effect_size", "estimator_id"]
+    rows = []
+    for values, block in frame.groupby(key, dropna=False):
+        groups = set(block["group"])
+        if {"structural", "ph_or_baseline"} <= groups:
+            means = block.groupby("group")[RMISE].mean()
+            rows.append(
+                {
+                    **dict(
+                        zip(key, values if isinstance(values, tuple) else (values,))
+                    ),
+                    "difference": float(means["structural"] - means["ph_or_baseline"]),
+                }
+            )
+    paired = pd.DataFrame.from_records(rows)
+    estimate = float(paired["difference"].mean()) if not paired.empty else float("nan")
+    return _record(
+        "H3",
+        "common_support_structural_minus_ph_or_baseline_rmise",
+        estimate,
+        supports=np.isfinite(estimate) and estimate > 0.0,
+        n=len(paired),
+        criterion="estimate > 0",
+        note=(
+            "PH estimators: "
+            + ", ".join(PROPORTIONAL_HAZARDS_ESTIMATORS)
+            + "; structural DGPs: "
+            + ", ".join(STRUCTURAL_VIOLATION_DGPS)
+        ),
+    )
+
+
+def _h4(summary: pd.DataFrame) -> dict[str, object]:
+    frame = _finite(summary, [RMISE, C_INDEX])
+    low = frame[frame["target_censoring"] == 0.1]
+    high = frame[frame["target_censoring"] == 0.7]
+    key = ["dgp", "n", "effect_size", "estimator_id"]
+    joined = high[key + [RMISE, C_INDEX]].merge(
+        low[key + [RMISE, C_INDEX]],
+        on=key,
+        how="inner",
+        suffixes=("_c70", "_c10"),
+    )
+    rmise_scale = float(frame[RMISE].std(ddof=1))
+    c_index_scale = float(frame[C_INDEX].std(ddof=1))
+    if joined.empty or rmise_scale <= 0 or c_index_scale <= 0:
+        estimate = float("nan")
+    else:
+        rmise_degradation = (
+            joined[f"{RMISE}_c70"] - joined[f"{RMISE}_c10"]
+        ) / rmise_scale
+        c_index_degradation = (
+            joined[f"{C_INDEX}_c10"] - joined[f"{C_INDEX}_c70"]
+        ) / c_index_scale
+        estimate = float(rmise_degradation.mean() - c_index_degradation.mean())
+
+    return _record(
+        "H4",
+        "common_support_standardised_rmise_degradation_minus_c_index_degradation",
+        estimate,
+        supports=np.isfinite(estimate) and estimate > 0.0,
+        n=len(joined),
+        criterion="estimate > 0",
+        note="paired on DGP, n, effect size and estimator; missing 10% cure cells drop out",
+    )
+
+
+def analyse_hypotheses(summary: pd.DataFrame) -> pd.DataFrame:
+    """Return one machine-readable row per preregistered hypothesis."""
+    required = {"scenario_id", "dgp", "estimator_id", RMISE, C_INDEX}
+    missing = sorted(required - set(summary.columns))
+    if missing:
+        raise ValueError(f"hypothesis analysis missing columns: {missing}")
+    return pd.DataFrame.from_records(
+        [_h1(summary), _h2(summary), _h3(summary), _h4(summary)]
+    )

--- a/research/discrimination-not-calibration/tests/test_hypotheses.py
+++ b/research/discrimination-not-calibration/tests/test_hypotheses.py
@@ -1,0 +1,68 @@
+"""Executable H1--H4 definitions."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from survival_misspec.hypotheses import analyse_hypotheses
+
+
+def _summary() -> pd.DataFrame:
+    rows = []
+    for dgp, misspecification in (
+        ("cphm", "none: proportional hazards, exponential baseline"),
+        ("piecewise_exponential", "baseline shape only: PH holds"),
+        ("aft_ln", "non-proportional hazards"),
+        ("aft_log_logistic", "non-proportional hazards"),
+        ("mixture_cure", "survival plateau"),
+    ):
+        censoring_levels = [0.5, 0.7] if dgp == "mixture_cure" else [0.1, 0.7]
+        for censoring in censoring_levels:
+            for estimator in ("cox_ph", "gradient_boosted", "random_survival_forest"):
+                base = 0.02 if dgp in {"cphm", "piecewise_exponential"} else 0.20
+                if estimator == "cox_ph" and dgp == "cphm":
+                    base = 0.001
+                if estimator == "random_survival_forest" and dgp == "cphm":
+                    base = 0.02
+                rmise = base + (0.04 if censoring == 0.7 else 0.0)
+                c_index = 0.65 - (0.01 if censoring == 0.7 else 0.0)
+                rows.append(
+                    {
+                        "scenario_id": f"{dgp}__c{int(censoring * 100)}",
+                        "dgp": dgp,
+                        "n": 250,
+                        "target_censoring": censoring,
+                        "effect_size": 0.5,
+                        "estimator_id": estimator,
+                        "misspecification": misspecification,
+                        "c_index_harrell_mean": c_index,
+                        "normalised_mise_mean": rmise**2,
+                        "root_mean_integrated_squared_error_mean": rmise,
+                    }
+                )
+    return pd.DataFrame.from_records(rows)
+
+
+def test_hypotheses_are_machine_readable() -> None:
+    hypotheses = analyse_hypotheses(_summary())
+
+    assert set(hypotheses["hypothesis"]) == {"H1", "H2", "H3", "H4"}
+    assert hypotheses["estimand"].notna().all()
+    assert hypotheses["criterion"].notna().all()
+
+
+def test_h2_uses_only_dgps_with_mapped_correct_references() -> None:
+    h2 = analyse_hypotheses(_summary()).set_index("hypothesis").loc["H2"]
+
+    assert h2["estimate"] == pytest.approx(400.0)
+    assert "aft_ln" not in h2["note"]
+    assert bool(h2["supports_hypothesis"])
+
+
+def test_h3_and_h4_use_common_support() -> None:
+    hypotheses = analyse_hypotheses(_summary()).set_index("hypothesis")
+
+    assert hypotheses.loc["H3", "n"] == 4
+    assert hypotheses.loc["H4", "n"] == 12
+    assert "common_support" in hypotheses.loc["H3", "estimand"]
+    assert "common_support" in hypotheses.loc["H4", "estimand"]

--- a/research/discrimination-not-calibration/tests/test_paper_artifacts.py
+++ b/research/discrimination-not-calibration/tests/test_paper_artifacts.py
@@ -56,7 +56,7 @@ def test_generated_tables_report_monte_carlo_error() -> None:
     """
     for path in _tables():
         text = path.read_text(encoding="utf-8")
-        if "table1" in path.name or "table2" in path.name:
+        if "table1" in path.name or "table2" in path.name or "table6" in path.name:
             continue
         if "---" in text and text.count("\\\\") < 3:
             continue  # a table with no data rows yet

--- a/research/discrimination-not-calibration/tests/test_pipeline.py
+++ b/research/discrimination-not-calibration/tests/test_pipeline.py
@@ -512,18 +512,22 @@ def test_compact_raw_writes_one_deterministic_file(tmp_path) -> None:
 
 
 def test_headline_metric_gap_operationalises_the_primary_claim() -> None:
-    raw = pd.DataFrame(
+    summary = pd.DataFrame(
         {
-            "scored": [True, True, True, True],
-            "c_index_harrell": [0.6, 0.61, 0.7, 0.71],
-            "root_mean_integrated_squared_error": [0.05, 0.20, 0.04, 0.30],
+            "c_index_harrell_mean": [0.6, 0.61, 0.7, 0.71],
+            "root_mean_integrated_squared_error_mean": [0.05, 0.20, 0.04, 0.30],
+            "root_mean_integrated_squared_error_mcse": [0.001] * 4,
         }
     )
 
-    headline = headline_metric_gap(raw, bins=2, quantile=0.9)
+    headline = headline_metric_gap(summary, bins=2, quantile=0.9)
 
-    assert list(headline["metric"]) == ["c_index_harrell", "c_index_harrell"]
+    assert list(headline["metric"]) == [
+        "c_index_harrell_mean",
+        "c_index_harrell_mean",
+    ]
     assert headline["loss_quantile"].max() == pytest.approx(0.274)
+    assert "loss_quantile_mcse" in headline.columns
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add executable H1-H4 definitions and an analyze_hypotheses.py stage
- compute headline quantiles from cell means with MCSE propagation
- add IPCW availability audit and grid convergence pass/fail criteria
- update reproduce/tables/figures/protocol/docs and artifact ignores for final freeze readiness

## Validation
- poetry run python -m pytest research\\discrimination-not-calibration\\tests
- smoke: audit_ipcw_availability.py --max-scenarios 1 --replications 2 --calibration-n 1000
- smoke: check_grid_convergence.py --max-scenarios 1 --estimators cox_ph --replications 1 --calibration-n 1000 --grid-points 11 21 --rmise-epsilon 0.01

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the final analysis stage for the discrimination-not-calibration study: executable H1–H4 hypothesis definitions, an IPCW availability audit, and pass/fail grid convergence criteria, so the study can be frozen and reproduced. The headline metric now propagates Monte Carlo error from cell means instead of raw rows.

- New `analyze_hypotheses.py` script writes `hypotheses.parquet` and `.json` from `summary.parquet`.
- New `audit_ipcw_availability.py` checks the IPCW grid stays within observed follow-up support and fails below 95% availability.
- `check_grid_convergence.py` now returns non-zero when the 51-point grid deviates from the 801-point baseline by more than 0.005 RMISE.
- `headline_metric_gap` computes the 90th percentile over scenario-estimator cell means and reports MCSE and 95% CI via parametric bootstrap.
- Table 6 reports the hypothesis results; reproducing now runs the new analysis steps before tables.

<sup>Written for commit 4e8886d3ad804ca826b7e7e5c15822c90b3fd35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

