### PR TITLE
Use conservative IPCW support grids

### DIFF
--- a/research/discrimination-not-calibration/README.md
+++ b/research/discrimination-not-calibration/README.md
@@ -66,7 +66,11 @@ without matching it:
 python scripts/make_config.py --production
 python scripts/freeze_experiment.py --out protocol/experiment_lock.json
 python scripts/check_ipcw_availability.py --minimum-availability 0.95
-python scripts/check_grid_convergence.py --replications 10 --rmise-epsilon 0.002
+python scripts/check_grid_convergence.py \
+    --summary results/processed/summary.parquet \
+    --top-cells 10 \
+    --replications 10 \
+    --rmise-epsilon 0.002
 python scripts/run_simulation.py \
     --out results/raw/production.parquet \
     --lock protocol/experiment_lock.json \

--- a/research/discrimination-not-calibration/protocol/preregistration.md
+++ b/research/discrimination-not-calibration/protocol/preregistration.md
@@ -152,7 +152,11 @@ would not be draws from one scenario.
 **The IPCW interval is resolved once per scenario and frozen.** Brier and
 time-dependent AUC implementations require evaluation times inside observed
 follow-up support. The production run uses the prespecified scenario-level
-grid; a replication that cannot support it records IBS and mean AUC as
+subgrid chosen from preparation-only matched train/evaluation support draws:
+the lower bound is the maximum matched lower support and the upper bound is the
+minimum matched upper support across the preparation draws; when possible, one
+additional grid point is dropped from each end of that interval. A replication
+that still cannot support this fixed interval records IBS and mean AUC as
 unavailable rather than shortening the interval after seeing that replication.
 
 **Cured subjects are excluded from the $\tau$ quantile.** `gen_mixture_cure`
@@ -200,10 +204,11 @@ $(\text{DGP},n,\beta,\text{estimator})$ support for 10% versus 70% censoring;
 Before freezing, `scripts/check_ipcw_availability.py` must pass with a minimum
 availability rate of 0.95 among feasible scenarios. The implementation lives in
 `scripts/audit_ipcw_availability.py`, which records the scenario-level audit.
-`scripts/check_grid_convergence.py` must pass with
+`scripts/check_grid_convergence.py` must pass on the 10 worst
+scenario-estimator cells by the latest processed cell-level loss summary, using
+at least 10 matched replications, with
 $|\mathrm{RMISE}_{51}-\mathrm{RMISE}_{801}| \le 0.002$ on the
-survival-probability scale, using at least 10 matched replications for the
-audited cells.
+survival-probability scale.
 
 No inferential test is used to declare an estimator superior. Conclusions are
 conditional on the mechanisms studied, and no claim of general superiority will

--- a/research/discrimination-not-calibration/scripts/check_grid_convergence.py
+++ b/research/discrimination-not-calibration/scripts/check_grid_convergence.py
@@ -5,6 +5,8 @@
 The production config uses 51 time points. This diagnostic reruns matched cells
 at 51, 201 and 801 points and compares each with the 801-point value. The
 default acceptance threshold is 0.002 RMISE on the survival-probability scale.
+The diagnostic only needs truth-loss metrics, so IPCW support-envelope
+preparation is disabled by default for speed.
 """
 
 from __future__ import annotations
@@ -14,13 +16,27 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent / "src"))
 
-from survival_misspec.config import load_study  # noqa: E402
-from survival_misspec.experiments import prepare_scenario, run_cell  # noqa: E402
+from survival_misspec.config import StudyConfig, load_study  # noqa: E402
+from survival_misspec.estimators import fit_estimator  # noqa: E402
+from survival_misspec.experiments import (  # noqa: E402
+    EVALUATION_N,
+    PreparedScenario,
+    prepare_scenario,
+)
+from survival_misspec.metrics import truth_recovery  # noqa: E402
+from survival_misspec.simulation import draw_replicate  # noqa: E402
+from survival_misspec.truth import true_survival  # noqa: E402
+
+DEFAULT_LOSS_COLUMNS = (
+    "root_mean_integrated_squared_error_mean",
+    "mise_mean",
+)
 
 
 def maximum_rmise_difference(frame: pd.DataFrame, reference_grid: int) -> float:
@@ -41,6 +57,102 @@ def grid_convergence_passes(
     return bool(pd.notna(maximum) and maximum <= rmise_epsilon)
 
 
+def select_audit_cells(
+    study: StudyConfig,
+    *,
+    summary: pd.DataFrame | None = None,
+    top_cells: int | None = None,
+    loss_column: str | None = None,
+) -> set[tuple[str, str]] | None:
+    """Scenario-estimator cells to audit, or ``None`` for the whole grid."""
+    if top_cells is None:
+        return None
+    if top_cells <= 0:
+        raise ValueError("top_cells must be positive")
+    if summary is None:
+        raise ValueError("top_cells requires a summary table")
+
+    required = {"scenario_id", "estimator_id"}
+    missing = sorted(required - set(summary.columns))
+    if missing:
+        raise ValueError(f"summary missing columns: {missing}")
+
+    candidates = [loss_column] if loss_column else list(DEFAULT_LOSS_COLUMNS)
+    metric = next((column for column in candidates if column in summary.columns), None)
+    if metric is None:
+        raise ValueError(
+            "summary does not contain any grid-audit loss column: "
+            + ", ".join(candidates)
+        )
+
+    frame = summary.copy()
+    frame[metric] = pd.to_numeric(frame[metric], errors="coerce")
+    available_scenarios = {scenario.scenario_id for scenario in study.scenarios}
+    available_estimators = {estimator.estimator_id for estimator in study.estimators}
+    frame = frame[
+        frame["scenario_id"].isin(available_scenarios)
+        & frame["estimator_id"].isin(available_estimators)
+    ].dropna(subset=[metric])
+    selected = frame.sort_values(metric, ascending=False).head(top_cells)
+    return {
+        (str(row.scenario_id), str(row.estimator_id)) for row in selected.itertuples()
+    }
+
+
+def score_replicate_across_grids(
+    prepared_by_grid: dict[int, PreparedScenario],
+    estimator,
+    replication_id: int,
+    master_seed: int,
+) -> dict[int, dict[str, float]]:
+    """Fit once, then evaluate truth loss on each candidate grid."""
+    if not prepared_by_grid:
+        return {}
+    prepared = next(iter(prepared_by_grid.values()))
+    scenario = prepared.config
+    train = draw_replicate(
+        scenario.dgp,
+        prepared.params,
+        scenario.n,
+        scenario.scenario_id,
+        replication_id,
+        master_seed,
+        stream="train",
+    )
+    evaluation = draw_replicate(
+        scenario.dgp,
+        prepared.params,
+        EVALUATION_N,
+        scenario.scenario_id,
+        replication_id,
+        master_seed,
+        stream="eval",
+    )
+    fitted = fit_estimator(
+        estimator.estimator_id,
+        estimator.adapter,
+        estimator.params,
+        train.covariates,
+        train.observed_time,
+        train.event,
+    )
+    if not fitted.fitted:
+        return {}
+
+    by_grid: dict[int, dict[str, float]] = {}
+    for points, grid_prepared in prepared_by_grid.items():
+        grid = np.asarray(grid_prepared.time_grid, dtype=float)
+        predicted = fitted.model.predict_survival(evaluation.covariates, grid)
+        truth = true_survival(scenario.dgp, grid, evaluation.truth, prepared.params)
+        by_grid[points] = truth_recovery(
+            predicted,
+            truth,
+            grid,
+            grid_prepared.tau,
+        )
+    return by_grid
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config", default=str(HERE.parent / "config"))
@@ -49,9 +161,31 @@ def main() -> int:
     )
     parser.add_argument("--grid-points", type=int, nargs="+", default=[51, 201, 801])
     parser.add_argument("--calibration-n", type=int, default=20000)
+    parser.add_argument(
+        "--ipcw-support-replications",
+        type=int,
+        default=0,
+        help="support-envelope draws during preparation; 0 is enough for RMISE",
+    )
     parser.add_argument("--replications", type=int, default=10)
     parser.add_argument("--max-scenarios", type=int, default=None)
     parser.add_argument("--estimators", nargs="*", default=None)
+    parser.add_argument(
+        "--summary",
+        default=None,
+        help="processed summary parquet used to select worst cells for the audit",
+    )
+    parser.add_argument(
+        "--top-cells",
+        type=int,
+        default=None,
+        help="audit only the top scenario-estimator cells by summary loss",
+    )
+    parser.add_argument(
+        "--loss-column",
+        default=None,
+        help="summary column used with --top-cells; defaults to RMISE then MISE",
+    )
     parser.add_argument(
         "--rmise-epsilon",
         type=float,
@@ -75,14 +209,34 @@ def main() -> int:
         if arguments.estimators is None
         or estimator.estimator_id in set(arguments.estimators)
     ]
+    summary = (
+        pd.read_parquet(arguments.summary) if arguments.summary is not None else None
+    )
+    selected_cells = select_audit_cells(
+        study,
+        summary=summary,
+        top_cells=arguments.top_cells,
+        loss_column=arguments.loss_column,
+    )
+    if selected_cells is not None:
+        print(
+            f"auditing top {len(selected_cells)} scenario-estimator cells", flush=True
+        )
 
     rows: list[dict[str, object]] = []
     for scenario in scenarios:
+        if selected_cells is not None and not any(
+            scenario.scenario_id == scenario_id for scenario_id, _ in selected_cells
+        ):
+            continue
         prepared_by_grid = {}
         for points in grid_points:
             metrics = replace(study.metrics, n_time_points=points)
             prepared = prepare_scenario(
-                scenario, metrics, calibration_n=arguments.calibration_n
+                scenario,
+                metrics,
+                calibration_n=arguments.calibration_n,
+                ipcw_support_replications=arguments.ipcw_support_replications,
             )
             if prepared.feasible:
                 prepared_by_grid[points] = prepared
@@ -90,17 +244,26 @@ def main() -> int:
             continue
 
         for estimator in estimators:
+            if (
+                selected_cells is not None
+                and (
+                    scenario.scenario_id,
+                    estimator.estimator_id,
+                )
+                not in selected_cells
+            ):
+                continue
+            print(
+                f"cell {scenario.scenario_id} / {estimator.estimator_id}",
+                flush=True,
+            )
             for replication_id in range(arguments.replications):
-                by_grid = {}
-                for points, prepared in prepared_by_grid.items():
-                    row = run_cell(
-                        prepared,
-                        estimator,
-                        replication_id,
-                        study.master_seed,
-                    )
-                    if row.get("scored"):
-                        by_grid[points] = row
+                by_grid = score_replicate_across_grids(
+                    prepared_by_grid,
+                    estimator,
+                    replication_id,
+                    study.master_seed,
+                )
                 if reference_grid not in by_grid:
                     continue
                 reference = by_grid[reference_grid]

--- a/research/discrimination-not-calibration/scripts/reproduce.py
+++ b/research/discrimination-not-calibration/scripts/reproduce.py
@@ -90,6 +90,10 @@ def main() -> int:
             [
                 python,
                 "scripts/check_grid_convergence.py",
+                "--summary",
+                "results/processed/summary.parquet",
+                "--top-cells",
+                "10",
                 "--replications",
                 "10",
                 "--rmise-epsilon",

--- a/research/discrimination-not-calibration/src/survival_misspec/experiments.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/experiments.py
@@ -45,6 +45,7 @@ __all__ = [
     "PreparedScenario",
     "prepare_scenario",
     "prepared_scenario_from_record",
+    "ipcw_support_grid",
     "PARAMETER_CORRESPONDENCE",
     "parameter_recovery",
     "run_cell",
@@ -59,6 +60,20 @@ EVALUATION_N = 4000
 #: Seed for scenario preparation only. Deliberately unrelated to any
 #: replication seed, so preparation cannot correlate with the data it defines.
 PREPARATION_SEED = 314159265
+
+#: Number of preparation-only matched train/evaluation draws used to place the
+#: scenario-level IPCW grid inside ordinary observed follow-up support. These
+#: draws are not production replications and use a separate seed stream.
+IPCW_SUPPORT_REPLICATIONS = 100
+
+#: Preparation support envelope used when fixing the IPCW grid before
+#: production. The acceptance gate remains 0.95; using the strict envelope from
+#: preparation draws gives the audit room for finite-sample tail noise.
+IPCW_SUPPORT_TARGET = 1.0
+
+#: Additional guard against placing a fixed IPCW point exactly next to the
+#: prospective support boundary. Only applied when enough grid points remain.
+IPCW_SUPPORT_TRIM_POINTS = 1
 
 
 @dataclass(frozen=True)
@@ -99,8 +114,82 @@ class PreparedScenario:
         }
 
 
+def ipcw_support_grid(
+    scenario: ScenarioConfig,
+    params: Mapping[str, Any],
+    grid: tuple[float, ...],
+    *,
+    support_replications: int = IPCW_SUPPORT_REPLICATIONS,
+    master_seed: int = PREPARATION_SEED,
+    evaluation_n: int = EVALUATION_N,
+    support_target: float = IPCW_SUPPORT_TARGET,
+    trim_points: int = IPCW_SUPPORT_TRIM_POINTS,
+) -> tuple[float, ...]:
+    """A fixed IPCW grid with prospective train/evaluation support.
+
+    Brier and time-dependent AUC require their time grid to lie inside the
+    observed support of both the training and evaluation samples. Instead of
+    taking the maximum observed time from a single large preparation draw, use
+    matched preparation-only draws to choose a conservative common-support
+    interval, then keep the ordinary tau-based grid points that fall inside it.
+    """
+    if support_replications <= 0:
+        return tuple(value for value in grid if value > 0.0)
+    if not 0.0 < support_target <= 1.0:
+        raise ValueError("support_target must be in (0, 1]")
+
+    lower_bounds = []
+    upper_bounds = []
+    for replication_id in range(support_replications):
+        train = draw_replicate(
+            scenario.dgp,
+            params,
+            scenario.n,
+            scenario.scenario_id,
+            replication_id,
+            master_seed,
+            stream="ipcw_train",
+        )
+        evaluation = draw_replicate(
+            scenario.dgp,
+            params,
+            evaluation_n,
+            scenario.scenario_id,
+            replication_id,
+            master_seed,
+            stream="ipcw_eval",
+        )
+        lower_bounds.append(
+            max(
+                float(np.min(train.observed_time)),
+                float(np.min(evaluation.observed_time)),
+            )
+        )
+        upper_bounds.append(
+            min(
+                float(np.max(train.observed_time)),
+                float(np.max(evaluation.observed_time)),
+            )
+        )
+
+    if support_target == 1.0:
+        lower = max(lower_bounds)
+        upper = min(upper_bounds)
+    else:
+        lower = float(np.quantile(lower_bounds, support_target))
+        upper = float(np.quantile(upper_bounds, 1.0 - support_target))
+    supported = tuple(value for value in grid if value > lower and value < upper)
+    if trim_points > 0 and len(supported) > 2 * trim_points:
+        return supported[trim_points:-trim_points]
+    return supported
+
+
 def prepare_scenario(
-    scenario: ScenarioConfig, metrics: MetricsConfig, *, calibration_n: int = 20000
+    scenario: ScenarioConfig,
+    metrics: MetricsConfig,
+    *,
+    calibration_n: int = 20000,
+    ipcw_support_replications: int = IPCW_SUPPORT_REPLICATIONS,
 ) -> PreparedScenario:
     """Resolve censoring and the evaluation horizon, once, before anything runs."""
     calibration = calibrate_censoring(
@@ -167,13 +256,11 @@ def prepare_scenario(
         )
 
     grid = tuple(np.linspace(0.0, tau, metrics.n_time_points).tolist())
-    observed = reference.data["time"].to_numpy(dtype=float)
-    lower = float(np.min(observed))
-    support_upper = float(np.max(observed))
-    ipcw_grid = tuple(
-        value
-        for value in grid
-        if value > lower and value <= tau and value < support_upper
+    ipcw_grid = ipcw_support_grid(
+        scenario,
+        params,
+        grid,
+        support_replications=ipcw_support_replications,
     )
 
     return PreparedScenario(

--- a/research/discrimination-not-calibration/tests/test_pipeline.py
+++ b/research/discrimination-not-calibration/tests/test_pipeline.py
@@ -598,6 +598,36 @@ def test_prepared_scenario_rehydrates_from_lock_record() -> None:
     assert loaded.ipcw_time_grid == prepared.ipcw_time_grid
 
 
+def test_ipcw_grid_uses_preparation_support_envelope(monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from survival_misspec import experiments
+    from survival_misspec.config import ScenarioConfig
+
+    def fake_draw_replicate(*args, **kwargs):
+        return SimpleNamespace(observed_time=np.array([1.5, 5.5]))
+
+    monkeypatch.setattr(experiments, "draw_replicate", fake_draw_replicate)
+    scenario = ScenarioConfig(
+        scenario_id="ipcw",
+        dgp="cphm",
+        n=100,
+        target_censoring=0.3,
+        effect_size=0.5,
+        params={},
+    )
+
+    grid = experiments.ipcw_support_grid(
+        scenario,
+        {"cens_par": 1.0},
+        (0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+        support_replications=3,
+        support_target=0.95,
+    )
+
+    assert grid == (3.0, 4.0)
+
+
 def test_cells_are_independent_of_the_order_they_are_run_in() -> None:
     """The property that makes parallel execution the same experiment.
 

--- a/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
+++ b/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
@@ -9,6 +9,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from survival_misspec.aggregation import headline_metric_gap
+from survival_misspec.config import (
+    EstimatorConfig,
+    MetricsConfig,
+    ScenarioConfig,
+    StudyConfig,
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -81,6 +87,36 @@ def test_grid_convergence_pass_fail_uses_preregistered_rmise_tolerance() -> None
     )
     assert grid.grid_convergence_passes(frame, reference_grid=801, rmise_epsilon=0.003)
     assert grid.maximum_rmise_difference(frame, 801) == pytest.approx(0.0021)
+
+
+def test_grid_convergence_selects_worst_cells_from_summary() -> None:
+    grid = _load_script("check_grid_convergence.py")
+    study = StudyConfig(
+        paper_id="p",
+        master_seed=1,
+        n_replications=1,
+        scenarios=(
+            ScenarioConfig("s1", "cphm", 100, 0.3, 0.5, {}),
+            ScenarioConfig("s2", "cphm", 100, 0.3, 0.5, {}),
+        ),
+        estimators=(
+            EstimatorConfig("cox_ph", "cox_ph"),
+            EstimatorConfig("weibull_aft", "weibull_aft"),
+        ),
+        metrics=MetricsConfig(0.8, 11, (0.5,), ("mise",)),
+    )
+    summary = pd.DataFrame(
+        {
+            "scenario_id": ["s1", "s1", "s2", "outside"],
+            "estimator_id": ["cox_ph", "weibull_aft", "cox_ph", "cox_ph"],
+            "root_mean_integrated_squared_error_mean": [0.1, 0.4, 0.2, 99.0],
+            "mise_mean": [0.5, 0.1, 0.9, 100.0],
+        }
+    )
+
+    selected = grid.select_audit_cells(study, summary=summary, top_cells=2)
+
+    assert selected == {("s1", "weibull_aft"), ("s2", "cox_ph")}
 
 
 def test_hypothesis_analysis_writes_manuscript_macros(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- choose each scenario's frozen IPCW subgrid from preparation-only matched train/evaluation support draws, trimming one endpoint grid point when possible
- make grid convergence practical by selecting top-loss scenario-estimator cells from the processed summary and fitting once per replication across all grid sizes
- wire the focused grid gate into the production workflow and document the prospective IPCW/grid criteria

## Freeze-gate checks run locally
- production lock generated from the committed branch source
- full IPCW availability gate: 216 scenarios audited, minimum feasible availability 0.980, threshold 0.95
- focused grid convergence gate: top 10 loss cells, 10 matched replications, max |RMISE - RMISE_801| 0.000710 <= 0.002

## Validation
- poetry run pre-commit run --all-files
- poetry run python -m pytest research\\discrimination-not-calibration\\tests
- poetry run mkdocs build --strict

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IPCW grid construction so the per-scenario time grid comes from a conservative support envelope over preparation-only matched draws instead of a single reference draw, and makes the grid convergence gate practical by limiting the audit to the worst cells.

- The grid is the intersection of matched train/evaluation support across preparation draws, with one endpoint trimmed from each side when enough points remain.
- The convergence diagnostic now fits each replication once and evaluates all grid sizes from that fit, instead of rerunning the cell per grid.
- The convergence gate now selects the top-loss cells from the processed summary via new CLI arguments.
- Production workflow and preregistration docs updated to reflect the new gate inputs and the conservative grid rule.

<sup>Written for commit 7909257a011fd0f3782f01df511f3fa1ca87b2d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

