### PR TITLE
Tighten research freeze contract

### DIFF
--- a/gen_surv/aft.py
+++ b/gen_surv/aft.py
@@ -104,7 +104,7 @@ def gen_aft_weibull(
     Simulate survival data under a Weibull Accelerated Failure Time (AFT) model.
 
     The Weibull AFT model has survival function:
-    S(t|X) = exp(-(t/scale)^shape * exp(-X*beta))
+    S(t|X) = exp(-(t/scale)^shape * exp(X*beta))
 
     Parameters
     ----------

--- a/research/discrimination-not-calibration/literature/positioning.md
+++ b/research/discrimination-not-calibration/literature/positioning.md
@@ -48,17 +48,17 @@ That is established, and recently and explicitly so. On the author's reading:
 
   **This study was doing the third.** Harrell's concordance was computed on each
   model's *native* risk: a partial hazard for Cox, a negative expected survival
-  time for the Weibull AFT, and scikit-survival's summed cumulative hazard for
+  time for the Weibull AFT, and scikit-survival's cumulative-hazard score for
   the forest and the boosted model. Three different mathematical objects
   compared with one measure, which is the comparison the paper calls virtually
   meaningless.
 
   Fixed by deriving the score from the predicted curve in one fixed way for
-  every model — expected mortality, the summed cumulative hazard over the
+  every model — the trapezoid-rule integral of cumulative hazard over the
   evaluation grid — so the only thing differing between estimators is the curve
   itself. The native scores are still reported, separately and under their own
   names, which the paper explicitly says is legitimate; only conflating them is
-  not. On the smoke case the change is nil for the parametric models and
+  not. On the smoke case the change is nil for the smooth/semiparametric models and
   −0.0067 for the forest, and it should matter more where hazards are not
   proportional.
 
@@ -206,11 +206,13 @@ survival curves are strictly monotonically decreasing.** Where a curve is flat,
 terms in the proof fail to cancel and buckets spanning the flat region take more
 than their share, inflating the statistic and over-rejecting. The random
 survival forest and gradient boosting predict step functions with exactly such
-flats, so part of their worse D-calibration in our results is an artefact of the
-measure rather than evidence about the model. The parametric estimators are
-unaffected. Censoring pushes the other way — it smooths the bucket proportions
-and raises the p-value — so the test is conservative under heavy censoring,
-which is also why Kaplan–Meier is only *asymptotically* D-calibrated.
+flats, and Cox predictions inherit the Breslow baseline's step structure. Part
+of their worse D-calibration in our results may therefore be an artefact of the
+measure rather than evidence about the model. Smooth parametric survival curves
+such as Weibull AFT are not affected in the same way. Censoring pushes the
+other way — it smooths the bucket proportions and raises the p-value — so the
+test is conservative under heavy censoring, which is also why Kaplan–Meier is
+only *asymptotically* D-calibrated.
 
 **A-calibration** (Simonsen & Waagepetersen 2025) is unread and unimplemented.
 Given the flat-region problem above it may be the better measure for the

--- a/research/discrimination-not-calibration/protocol/estimands.md
+++ b/research/discrimination-not-calibration/protocol/estimands.md
@@ -96,9 +96,22 @@ predicted probabilities are uniformly far too high can attain the same
 concordance as one that is exactly right. That invariance is the formal reason
 the paper's question is not vacuous.
 
-Concordance is reported both on each model's native risk score and on
-$1 - \hat S_i(\tau)$. Under proportional hazards the two coincide; where they
-differ, the ranking itself depends on the horizon, which is worth seeing.
+The primary Harrell and Uno concordances use one transformation for every
+estimator:
+
+$$
+\hat r_i^{\mathrm{IH}}
+  = \int_0^\tau -\log \hat S_i(t)\,dt,
+$$
+
+computed by the same trapezoid rule used for every time integral. In result
+tables this is named `c_index_harrell_integrated_hazard`; the legacy
+`c_index_harrell` column is the same quantity for backward-compatible plotting.
+
+Concordance is also reported on each model's native risk score and on
+$1 - \hat S_i(\tau)$. Under proportional hazards these rankings usually agree;
+where they differ, the ranking itself depends on the horizon, which is worth
+seeing.
 
 ---
 
@@ -115,9 +128,10 @@ replication is observed.
 D-calibration is reported as a distributional diagnostic, not as a like-for-like
 comparative primary measure for all estimators. Haider et al.'s theorem assumes
 strictly decreasing survival curves, while the random survival forest and
-gradient-boosted estimators return flat step functions. Their D-calibration
-results must therefore be read with that non-comparability qualification unless
-an alternative such as A-calibration is added before the production lock.
+gradient-boosted estimators return flat step functions and Cox predictions
+inherit the Breslow baseline's step structure. Their D-calibration results must
+therefore be read with that non-comparability qualification unless an
+alternative such as A-calibration is added before the production lock.
 
 **These use only observed, censored data.** That is their role in the argument:
 they are what an analyst without access to the truth can compute. The

--- a/research/discrimination-not-calibration/scripts/analyze_hypotheses.py
+++ b/research/discrimination-not-calibration/scripts/analyze_hypotheses.py
@@ -30,6 +30,7 @@ HYPOTHESIS_WORDS = {
     "H1": "HOne",
     "H2": "HTwo",
     "H3": "HThree",
+    "H3b": "HThreeB",
     "H4": "HFour",
 }
 

--- a/research/discrimination-not-calibration/scripts/audit_ipcw_availability.py
+++ b/research/discrimination-not-calibration/scripts/audit_ipcw_availability.py
@@ -19,7 +19,9 @@ import pandas as pd
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent / "src"))
+sys.path.insert(0, str(HERE))
 
+from gate_artifacts import add_metadata, study_metadata  # noqa: E402
 from survival_misspec.config import load_study  # noqa: E402
 from survival_misspec.experiments import EVALUATION_N, prepare_scenario  # noqa: E402
 from survival_misspec.simulation import draw_replicate  # noqa: E402
@@ -91,7 +93,12 @@ def main() -> int:
         "--out", default=str(HERE.parent / "results" / "ipcw_availability.parquet")
     )
     parser.add_argument("--calibration-n", type=int, default=20000)
-    parser.add_argument("--replications", type=int, default=50)
+    parser.add_argument(
+        "--replications",
+        type=int,
+        default=None,
+        help="replications to audit; defaults to the full planned production R",
+    )
     parser.add_argument("--max-scenarios", type=int, default=None)
     parser.add_argument(
         "--minimum-availability",
@@ -102,7 +109,15 @@ def main() -> int:
     arguments = parser.parse_args()
 
     study = load_study(arguments.config)
+    replications = arguments.replications or study.n_replications
     rows: list[dict[str, object]] = []
+    metadata = study_metadata(study)
+    metadata.update(
+        {
+            "audited_replications": replications,
+            "minimum_availability_threshold": arguments.minimum_availability,
+        }
+    )
     scenarios = list(study.scenarios)
     if arguments.max_scenarios is not None:
         scenarios = scenarios[: arguments.max_scenarios]
@@ -113,19 +128,23 @@ def main() -> int:
         )
         if not prepared.feasible:
             rows.append(
-                {
-                    "scenario_id": scenario.scenario_id,
-                    "dgp": scenario.dgp,
-                    "n": scenario.n,
-                    "target_censoring": scenario.target_censoring,
-                    "effect_size": scenario.effect_size,
-                    "feasible": False,
-                    "availability": float("nan"),
-                    "supported": 0,
-                    "attempted": 0,
-                    "passes": False,
-                    "reason": prepared.reason,
-                }
+                add_metadata(
+                    {
+                        "scenario_id": scenario.scenario_id,
+                        "scenario_hash": scenario.hash,
+                        "dgp": scenario.dgp,
+                        "n": scenario.n,
+                        "target_censoring": scenario.target_censoring,
+                        "effect_size": scenario.effect_size,
+                        "feasible": False,
+                        "availability": float("nan"),
+                        "supported": 0,
+                        "attempted": 0,
+                        "passes": False,
+                        "reason": prepared.reason,
+                    },
+                    metadata,
+                )
             )
             continue
 
@@ -133,22 +152,26 @@ def main() -> int:
             scenario,
             prepared,
             master_seed=study.master_seed,
-            replications=arguments.replications,
+            replications=replications,
         )
         rows.append(
-            {
-                "scenario_id": scenario.scenario_id,
-                "dgp": scenario.dgp,
-                "n": scenario.n,
-                "target_censoring": scenario.target_censoring,
-                "effect_size": scenario.effect_size,
-                "feasible": True,
-                "availability": availability,
-                "supported": supported,
-                "attempted": arguments.replications,
-                "passes": availability >= arguments.minimum_availability,
-                "reason": "",
-            }
+            add_metadata(
+                {
+                    "scenario_id": scenario.scenario_id,
+                    "scenario_hash": scenario.hash,
+                    "dgp": scenario.dgp,
+                    "n": scenario.n,
+                    "target_censoring": scenario.target_censoring,
+                    "effect_size": scenario.effect_size,
+                    "feasible": True,
+                    "availability": availability,
+                    "supported": supported,
+                    "attempted": replications,
+                    "passes": availability >= arguments.minimum_availability,
+                    "reason": "",
+                },
+                metadata,
+            )
         )
 
     frame = pd.DataFrame.from_records(rows)

--- a/research/discrimination-not-calibration/scripts/check_grid_convergence.py
+++ b/research/discrimination-not-calibration/scripts/check_grid_convergence.py
@@ -5,6 +5,8 @@
 The production config uses 51 time points. This diagnostic reruns matched cells
 at 51, 201 and 801 points and compares each with the 801-point value. The
 default acceptance threshold is 0.002 RMISE on the survival-probability scale.
+It also checks that the integrated-hazard Harrell C-index is numerically stable
+against the finest grid.
 The diagnostic only needs truth-loss metrics, so IPCW support-envelope
 preparation is disabled by default for speed.
 """
@@ -21,7 +23,9 @@ import pandas as pd
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE.parent / "src"))
+sys.path.insert(0, str(HERE))
 
+from gate_artifacts import add_metadata, file_sha256, study_metadata  # noqa: E402
 from survival_misspec.config import StudyConfig, load_study  # noqa: E402
 from survival_misspec.estimators import fit_estimator  # noqa: E402
 from survival_misspec.experiments import (  # noqa: E402
@@ -29,7 +33,11 @@ from survival_misspec.experiments import (  # noqa: E402
     PreparedScenario,
     prepare_scenario,
 )
-from survival_misspec.metrics import truth_recovery  # noqa: E402
+from survival_misspec.metrics import (  # noqa: E402
+    discrimination,
+    expected_mortality,
+    truth_recovery,
+)
 from survival_misspec.simulation import draw_replicate  # noqa: E402
 from survival_misspec.truth import true_survival  # noqa: E402
 
@@ -49,12 +57,35 @@ def maximum_rmise_difference(frame: pd.DataFrame, reference_grid: int) -> float:
     )
 
 
+def maximum_c_index_difference(frame: pd.DataFrame, reference_grid: int) -> float:
+    """Maximum absolute integrated-hazard C-index difference."""
+    comparisons = frame[frame["n_time_points"] != reference_grid]
+    if comparisons.empty:
+        return float("nan")
+    return float(
+        pd.to_numeric(
+            comparisons["c_index_harrell_integrated_hazard_absolute_difference"],
+            errors="coerce",
+        ).max()
+    )
+
+
 def grid_convergence_passes(
-    frame: pd.DataFrame, *, reference_grid: int, rmise_epsilon: float
+    frame: pd.DataFrame,
+    *,
+    reference_grid: int,
+    rmise_epsilon: float,
+    c_index_epsilon: float = 0.002,
 ) -> bool:
     """Return whether the pre-freeze grid-convergence criterion passes."""
-    maximum = maximum_rmise_difference(frame, reference_grid)
-    return bool(pd.notna(maximum) and maximum <= rmise_epsilon)
+    maximum_rmise = maximum_rmise_difference(frame, reference_grid)
+    maximum_c_index = maximum_c_index_difference(frame, reference_grid)
+    return bool(
+        pd.notna(maximum_rmise)
+        and maximum_rmise <= rmise_epsilon
+        and pd.notna(maximum_c_index)
+        and maximum_c_index <= c_index_epsilon
+    )
 
 
 def select_audit_cells(
@@ -144,12 +175,21 @@ def score_replicate_across_grids(
         grid = np.asarray(grid_prepared.time_grid, dtype=float)
         predicted = fitted.model.predict_survival(evaluation.covariates, grid)
         truth = true_survival(scenario.dgp, grid, evaluation.truth, prepared.params)
-        by_grid[points] = truth_recovery(
+        row = truth_recovery(
             predicted,
             truth,
             grid,
             grid_prepared.tau,
         )
+        row["c_index_harrell_integrated_hazard"] = discrimination(
+            expected_mortality(predicted, grid),
+            train.observed_time,
+            train.event,
+            evaluation.observed_time,
+            evaluation.event,
+            grid_prepared.tau,
+        )["c_index_harrell"]
+        by_grid[points] = row
     return by_grid
 
 
@@ -192,6 +232,15 @@ def main() -> int:
         default=0.002,
         help="maximum acceptable absolute RMISE difference versus the finest grid",
     )
+    parser.add_argument(
+        "--c-index-epsilon",
+        type=float,
+        default=0.002,
+        help=(
+            "maximum acceptable absolute integrated-hazard Harrell C-index "
+            "difference versus the finest grid"
+        ),
+    )
     arguments = parser.parse_args()
 
     study = load_study(arguments.config)
@@ -209,9 +258,8 @@ def main() -> int:
         if arguments.estimators is None
         or estimator.estimator_id in set(arguments.estimators)
     ]
-    summary = (
-        pd.read_parquet(arguments.summary) if arguments.summary is not None else None
-    )
+    summary_path = Path(arguments.summary) if arguments.summary is not None else None
+    summary = pd.read_parquet(summary_path) if summary_path is not None else None
     selected_cells = select_audit_cells(
         study,
         summary=summary,
@@ -222,6 +270,20 @@ def main() -> int:
         print(
             f"auditing top {len(selected_cells)} scenario-estimator cells", flush=True
         )
+
+    metadata = study_metadata(study)
+    metadata.update(
+        {
+            "audited_replications": arguments.replications,
+            "rmise_epsilon": arguments.rmise_epsilon,
+            "c_index_epsilon": arguments.c_index_epsilon,
+            "selected_summary_sha256": (
+                file_sha256(summary_path) if summary_path is not None else ""
+            ),
+            "top_cells": arguments.top_cells or 0,
+            "loss_column": arguments.loss_column or "",
+        }
+    )
 
     rows: list[dict[str, object]] = []
     for scenario in scenarios:
@@ -269,26 +331,41 @@ def main() -> int:
                 reference = by_grid[reference_grid]
                 for points, row in by_grid.items():
                     rows.append(
-                        {
-                            "scenario_id": scenario.scenario_id,
-                            "estimator_id": estimator.estimator_id,
-                            "replication_id": replication_id,
-                            "n_time_points": points,
-                            "reference_n_time_points": reference_grid,
-                            "mise": row["mise"],
-                            "rmise": row["root_mean_integrated_squared_error"],
-                            "mise_reference": reference["mise"],
-                            "rmise_reference": reference[
-                                "root_mean_integrated_squared_error"
-                            ],
-                            "mise_absolute_difference": abs(
-                                row["mise"] - reference["mise"]
-                            ),
-                            "rmise_absolute_difference": abs(
-                                row["root_mean_integrated_squared_error"]
-                                - reference["root_mean_integrated_squared_error"]
-                            ),
-                        }
+                        add_metadata(
+                            {
+                                "scenario_id": scenario.scenario_id,
+                                "scenario_hash": scenario.hash,
+                                "estimator_id": estimator.estimator_id,
+                                "estimator_hash": estimator.hash,
+                                "replication_id": replication_id,
+                                "n_time_points": points,
+                                "reference_n_time_points": reference_grid,
+                                "mise": row["mise"],
+                                "rmise": row["root_mean_integrated_squared_error"],
+                                "c_index_harrell_integrated_hazard": row[
+                                    "c_index_harrell_integrated_hazard"
+                                ],
+                                "mise_reference": reference["mise"],
+                                "rmise_reference": reference[
+                                    "root_mean_integrated_squared_error"
+                                ],
+                                "c_index_harrell_integrated_hazard_reference": reference[
+                                    "c_index_harrell_integrated_hazard"
+                                ],
+                                "mise_absolute_difference": abs(
+                                    row["mise"] - reference["mise"]
+                                ),
+                                "rmise_absolute_difference": abs(
+                                    row["root_mean_integrated_squared_error"]
+                                    - reference["root_mean_integrated_squared_error"]
+                                ),
+                                "c_index_harrell_integrated_hazard_absolute_difference": abs(
+                                    row["c_index_harrell_integrated_hazard"]
+                                    - reference["c_index_harrell_integrated_hazard"]
+                                ),
+                            },
+                            metadata,
+                        )
                     )
 
     if not rows:
@@ -303,23 +380,35 @@ def main() -> int:
     summary = (
         frame[frame["n_time_points"] != reference_grid]
         .groupby("n_time_points")[
-            ["mise_absolute_difference", "rmise_absolute_difference"]
+            [
+                "mise_absolute_difference",
+                "rmise_absolute_difference",
+                "c_index_harrell_integrated_hazard_absolute_difference",
+            ]
         ]
         .max()
     )
     print(summary.to_string())
-    maximum = maximum_rmise_difference(frame, reference_grid)
+    maximum_rmise = maximum_rmise_difference(frame, reference_grid)
+    maximum_c_index = maximum_c_index_difference(frame, reference_grid)
     if grid_convergence_passes(
-        frame, reference_grid=reference_grid, rmise_epsilon=arguments.rmise_epsilon
+        frame,
+        reference_grid=reference_grid,
+        rmise_epsilon=arguments.rmise_epsilon,
+        c_index_epsilon=arguments.c_index_epsilon,
     ):
         print(
             f"criterion pass: max |RMISE - RMISE_{reference_grid}| "
-            f"{maximum:.6f} <= {arguments.rmise_epsilon:.6f}"
+            f"{maximum_rmise:.6f} <= {arguments.rmise_epsilon:.6f}; "
+            f"max |C - C_{reference_grid}| "
+            f"{maximum_c_index:.6f} <= {arguments.c_index_epsilon:.6f}"
         )
         return 0
     print(
         f"criterion fail: max |RMISE - RMISE_{reference_grid}| "
-        f"{maximum:.6f} > {arguments.rmise_epsilon:.6f}"
+        f"{maximum_rmise:.6f} > {arguments.rmise_epsilon:.6f} or "
+        f"max |C - C_{reference_grid}| "
+        f"{maximum_c_index:.6f} > {arguments.c_index_epsilon:.6f}"
     )
     return 2
 

--- a/research/discrimination-not-calibration/scripts/freeze_experiment.py
+++ b/research/discrimination-not-calibration/scripts/freeze_experiment.py
@@ -10,7 +10,6 @@ and writes the hash that production rows must carry when they are resumed.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import sys
 from pathlib import Path
 
@@ -23,32 +22,86 @@ sys.path.insert(0, str(HERE))
 from audit_ipcw_availability import availability_passes  # noqa: E402
 from check_grid_convergence import (  # noqa: E402
     grid_convergence_passes,
+    maximum_c_index_difference,
     maximum_rmise_difference,
+    select_audit_cells,
 )
-from survival_misspec.config import load_study  # noqa: E402
+from gate_artifacts import file_sha256, metadata_problems  # noqa: E402
+from survival_misspec.config import StudyConfig, load_study  # noqa: E402
 from survival_misspec.experiments import prepare_scenario  # noqa: E402
 from survival_misspec.validation import write_lock  # noqa: E402
 
 
-def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def _fail_if_any(problems: list[str], *, artifact: Path) -> None:
+    if problems:
+        raise SystemExit(
+            f"gate artifact does not match the current production contract: {artifact}\n"
+            + "\n".join(f"  - {problem}" for problem in problems)
+        )
 
 
-def _ipcw_gate_evidence(path: Path, minimum_availability: float) -> dict[str, object]:
+def _ipcw_gate_evidence(
+    path: Path, minimum_availability: float, study: StudyConfig
+) -> dict[str, object]:
     if not path.exists():
         raise SystemExit(f"missing IPCW gate artifact: {path}")
     frame = pd.read_parquet(path)
+    problems = metadata_problems(
+        frame,
+        study,
+        expected={
+            "audited_replications": study.n_replications,
+            "minimum_availability_threshold": minimum_availability,
+        },
+    )
+    scenario_ids = {scenario.scenario_id for scenario in study.scenarios}
+    artifact_ids = set(frame.get("scenario_id", pd.Series(dtype=str)).astype(str))
+    missing = sorted(scenario_ids - artifact_ids)
+    extra = sorted(artifact_ids - scenario_ids)
+    if missing:
+        problems.append(f"IPCW artifact is missing scenarios: {missing[:10]}")
+    if extra:
+        problems.append(f"IPCW artifact contains unknown scenarios: {extra[:10]}")
+    if "scenario_hash" in frame.columns:
+        hashes = {
+            str(row.scenario_id): row.scenario_hash
+            for row in frame[["scenario_id", "scenario_hash"]].itertuples()
+        }
+        for scenario in study.scenarios:
+            if hashes.get(scenario.scenario_id) != scenario.hash:
+                problems.append(
+                    f"scenario_hash mismatch for {scenario.scenario_id}: "
+                    f"{hashes.get(scenario.scenario_id)} != {scenario.hash}"
+                )
+    else:
+        problems.append("IPCW artifact missing scenario_hash")
+    if "attempted" in frame.columns:
+        feasible = frame[frame["feasible"]]
+        attempted = pd.to_numeric(feasible["attempted"], errors="coerce")
+        if not (attempted == study.n_replications).all():
+            problems.append(
+                "not every feasible scenario audited all planned replications"
+            )
+    else:
+        problems.append("IPCW artifact missing attempted")
+    _fail_if_any(problems, artifact=path)
     if not availability_passes(frame, minimum_availability=minimum_availability):
         raise SystemExit(
             f"IPCW availability gate failed in {path}; rerun "
-            "scripts/check_ipcw_availability.py before freezing"
+            "scripts/audit_ipcw_availability.py before freezing"
         )
     feasible = frame[frame["feasible"]]
     return {
         "artifact": str(path),
-        "sha256": _sha256(path),
+        "sha256": file_sha256(path),
         "status": "PASS",
         "threshold": float(minimum_availability),
+        "study_hash": study.hash,
+        "git_commit": str(frame["git_commit"].iloc[0]),
+        "scenario_design_hash": str(frame["scenario_design_hash"].iloc[0]),
+        "estimator_design_hash": str(frame["estimator_design_hash"].iloc[0]),
+        "metrics_hash": str(frame["metrics_hash"].iloc[0]),
+        "audited_replications": study.n_replications,
         "minimum_availability": (
             float(feasible["availability"].min())
             if not feasible.empty
@@ -59,16 +112,73 @@ def _ipcw_gate_evidence(path: Path, minimum_availability: float) -> dict[str, ob
     }
 
 
-def _grid_gate_evidence(path: Path, rmise_epsilon: float) -> dict[str, object]:
+def _grid_gate_evidence(
+    path: Path,
+    rmise_epsilon: float,
+    c_index_epsilon: float,
+    study: StudyConfig,
+    summary_path: Path,
+    top_cells: int,
+    minimum_replications: int,
+) -> dict[str, object]:
     if not path.exists():
         raise SystemExit(f"missing grid-convergence gate artifact: {path}")
+    if not summary_path.exists():
+        raise SystemExit(f"missing grid-convergence selection summary: {summary_path}")
     frame = pd.read_parquet(path)
     if frame.empty or "reference_n_time_points" not in frame.columns:
         raise SystemExit(f"grid-convergence gate artifact is incomplete: {path}")
+    problems = metadata_problems(
+        frame,
+        study,
+        expected={
+            "rmise_epsilon": rmise_epsilon,
+            "c_index_epsilon": c_index_epsilon,
+            "selected_summary_sha256": file_sha256(summary_path),
+            "top_cells": top_cells,
+        },
+    )
+    summary = pd.read_parquet(summary_path)
+    selected = select_audit_cells(study, summary=summary, top_cells=top_cells)
+    artifact_cells = {
+        (str(row.scenario_id), str(row.estimator_id))
+        for row in frame[["scenario_id", "estimator_id"]].drop_duplicates().itertuples()
+    }
+    if artifact_cells != selected:
+        problems.append(
+            "grid artifact cells do not match the current selected worst cells"
+        )
+    if "replication_id" in frame.columns:
+        replication_counts = frame.groupby(["scenario_id", "estimator_id"])[
+            "replication_id"
+        ].nunique()
+        if (
+            replication_counts.empty
+            or (replication_counts < minimum_replications).any()
+        ):
+            problems.append(
+                f"each grid cell must contain at least {minimum_replications} "
+                "matched replications"
+            )
+    else:
+        problems.append("grid artifact missing replication_id")
+    if "audited_replications" in frame.columns:
+        audited = pd.to_numeric(frame["audited_replications"], errors="coerce")
+        if (audited < minimum_replications).any():
+            problems.append(
+                f"grid artifact audited fewer than {minimum_replications} replications"
+            )
+    else:
+        problems.append("grid artifact missing audited_replications")
+    _fail_if_any(problems, artifact=path)
     reference_grid = int(pd.to_numeric(frame["reference_n_time_points"]).max())
-    maximum = maximum_rmise_difference(frame, reference_grid)
+    maximum_rmise = maximum_rmise_difference(frame, reference_grid)
+    maximum_c_index = maximum_c_index_difference(frame, reference_grid)
     if not grid_convergence_passes(
-        frame, reference_grid=reference_grid, rmise_epsilon=rmise_epsilon
+        frame,
+        reference_grid=reference_grid,
+        rmise_epsilon=rmise_epsilon,
+        c_index_epsilon=c_index_epsilon,
     ):
         raise SystemExit(
             f"grid-convergence gate failed in {path}; rerun "
@@ -76,10 +186,20 @@ def _grid_gate_evidence(path: Path, rmise_epsilon: float) -> dict[str, object]:
         )
     return {
         "artifact": str(path),
-        "sha256": _sha256(path),
+        "sha256": file_sha256(path),
         "status": "PASS",
-        "threshold": float(rmise_epsilon),
-        "maximum_rmise_difference": float(maximum),
+        "rmise_threshold": float(rmise_epsilon),
+        "c_index_threshold": float(c_index_epsilon),
+        "study_hash": study.hash,
+        "git_commit": str(frame["git_commit"].iloc[0]),
+        "scenario_design_hash": str(frame["scenario_design_hash"].iloc[0]),
+        "estimator_design_hash": str(frame["estimator_design_hash"].iloc[0]),
+        "metrics_hash": str(frame["metrics_hash"].iloc[0]),
+        "selected_summary_sha256": file_sha256(summary_path),
+        "top_cells": top_cells,
+        "audited_replications": minimum_replications,
+        "maximum_rmise_difference": float(maximum_rmise),
+        "maximum_c_index_difference": float(maximum_c_index),
         "reference_n_time_points": reference_grid,
         "rows": int(len(frame)),
     }
@@ -106,6 +226,14 @@ def main() -> int:
     )
     parser.add_argument("--minimum-availability", type=float, default=0.95)
     parser.add_argument("--rmise-epsilon", type=float, default=0.002)
+    parser.add_argument("--c-index-epsilon", type=float, default=0.002)
+    parser.add_argument(
+        "--grid-summary",
+        default=str(HERE.parent / "results" / "processed" / "summary.parquet"),
+        help="summary parquet whose worst cells selected the grid gate",
+    )
+    parser.add_argument("--grid-top-cells", type=int, default=10)
+    parser.add_argument("--grid-minimum-replications", type=int, default=10)
     parser.add_argument(
         "--skip-gate-checks",
         action="store_true",
@@ -123,10 +251,16 @@ def main() -> int:
     if not arguments.skip_gate_checks:
         gate_evidence = {
             "ipcw_availability": _ipcw_gate_evidence(
-                Path(arguments.ipcw_gate), arguments.minimum_availability
+                Path(arguments.ipcw_gate), arguments.minimum_availability, study
             ),
             "grid_convergence": _grid_gate_evidence(
-                Path(arguments.grid_gate), arguments.rmise_epsilon
+                Path(arguments.grid_gate),
+                arguments.rmise_epsilon,
+                arguments.c_index_epsilon,
+                study,
+                Path(arguments.grid_summary),
+                arguments.grid_top_cells,
+                arguments.grid_minimum_replications,
             ),
         }
     prepared = []

--- a/research/discrimination-not-calibration/scripts/gate_artifacts.py
+++ b/research/discrimination-not-calibration/scripts/gate_artifacts.py
@@ -1,0 +1,110 @@
+"""Shared metadata and validation helpers for pre-freeze gate artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from survival_misspec.config import StudyConfig, content_hash
+from survival_misspec.validation import capture_provenance
+
+
+def file_sha256(path: Path) -> str:
+    """SHA-256 digest of an artifact exactly as written."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def scenario_design_hash(study: StudyConfig) -> str:
+    """Hash of the declared scenario set independent of row order."""
+    return content_hash(
+        {scenario.scenario_id: scenario.hash for scenario in study.scenarios}
+    )
+
+
+def estimator_design_hash(study: StudyConfig) -> str:
+    """Hash of the declared estimator set independent of row order."""
+    return content_hash(
+        {estimator.estimator_id: estimator.hash for estimator in study.estimators}
+    )
+
+
+def study_metadata(study: StudyConfig) -> dict[str, object]:
+    """Metadata every pre-freeze gate artifact must carry."""
+    provenance = capture_provenance()
+    return {
+        "study_hash": study.hash,
+        "git_commit": provenance.git_commit,
+        "git_tree_clean": provenance.git_tree_clean,
+        "n_replications_planned": study.n_replications,
+        "scenario_design_hash": scenario_design_hash(study),
+        "estimator_design_hash": estimator_design_hash(study),
+        "metrics_hash": study.metrics.hash,
+    }
+
+
+def add_metadata(
+    row: dict[str, object], metadata: dict[str, object]
+) -> dict[str, object]:
+    """Return a row with common gate metadata appended."""
+    return {**row, **metadata}
+
+
+def _unique(frame: pd.DataFrame, column: str) -> list[Any]:
+    if column not in frame.columns:
+        return []
+    return frame[column].drop_duplicates().tolist()
+
+
+def metadata_problems(
+    frame: pd.DataFrame,
+    study: StudyConfig,
+    *,
+    expected: dict[str, object] | None = None,
+) -> list[str]:
+    """Validate gate metadata against the current declared study."""
+    required = {
+        "study_hash",
+        "git_commit",
+        "git_tree_clean",
+        "n_replications_planned",
+        "scenario_design_hash",
+        "estimator_design_hash",
+        "metrics_hash",
+    }
+    problems: list[str] = []
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        return [f"gate artifact missing metadata columns: {missing}"]
+
+    expected_values: dict[str, object] = {
+        "study_hash": study.hash,
+        "n_replications_planned": study.n_replications,
+        "scenario_design_hash": scenario_design_hash(study),
+        "estimator_design_hash": estimator_design_hash(study),
+        "metrics_hash": study.metrics.hash,
+    }
+    if expected:
+        expected_values.update(expected)
+
+    for column, wanted in expected_values.items():
+        values = _unique(frame, column)
+        if len(values) != 1 or values[0] != wanted:
+            problems.append(
+                f"{column} mismatch: artifact has {values[:3]} but expected {wanted}"
+            )
+
+    clean_values = _unique(frame, "git_tree_clean")
+    if clean_values != [True]:
+        problems.append("gate artifact was not produced from a clean tree")
+
+    current_commit = capture_provenance().git_commit
+    commit_values = _unique(frame, "git_commit")
+    if len(commit_values) != 1 or commit_values[0] != current_commit:
+        problems.append(
+            f"git_commit mismatch: artifact has {commit_values[:3]} "
+            f"but current is {current_commit}"
+        )
+
+    return problems

--- a/research/discrimination-not-calibration/scripts/run_pilot.py
+++ b/research/discrimination-not-calibration/scripts/run_pilot.py
@@ -24,6 +24,8 @@ prevent for the results that get reported. Everything written here goes to
 from __future__ import annotations
 
 import argparse
+import json
+import math
 import sys
 from pathlib import Path
 
@@ -36,15 +38,46 @@ sys.path.insert(0, str(HERE.parent / "src"))
 from survival_misspec.aggregation import (  # noqa: E402
     aggregate,
     failure_rates,
+    headline_metric_gap,
     read_raw,
     replications_for_precision,
 )
+from survival_misspec.hypotheses import analyse_hypotheses  # noqa: E402
 
-#: The Monte Carlo precision the conclusions need, on the scale of the primary
-#: loss. MISE is a squared survival probability integrated over the horizon;
-#: a standard error of 0.001 is small next to the differences the paper is
-#: about, which the pilot quantifies below.
+#: Historical MISE-scale pilot diagnostic. The freeze decision is supported by
+#: the explicit RMISE/H1-H4/headline precision report written below, without
+#: automatically changing the planned production replication count.
 TARGET_MCSE_MISE = 0.001
+PRODUCTION_REPLICATIONS = 500
+
+
+def _project_summary_mcse(
+    summary: pd.DataFrame, target_replications: int
+) -> pd.DataFrame:
+    """Scale cell MCSE columns to a prospective production replication count."""
+    projected = summary.copy()
+    if (
+        "c_index_harrell_integrated_hazard_mean" not in projected.columns
+        and "c_index_harrell_mean" in projected.columns
+    ):
+        projected["c_index_harrell_integrated_hazard_mean"] = projected[
+            "c_index_harrell_mean"
+        ]
+        if "c_index_harrell_mcse" in projected.columns:
+            projected["c_index_harrell_integrated_hazard_mcse"] = projected[
+                "c_index_harrell_mcse"
+            ]
+
+    for column in [name for name in projected.columns if name.endswith("_mcse")]:
+        count_column = column.removesuffix("_mcse") + "_n"
+        if count_column in projected.columns:
+            counts = pd.to_numeric(projected[count_column], errors="coerce")
+        else:
+            counts = pd.Series(target_replications, index=projected.index)
+        projected[column] = pd.to_numeric(projected[column], errors="coerce") * np.sqrt(
+            counts / target_replications
+        )
+    return projected
 
 
 def section(title: str) -> None:
@@ -126,17 +159,22 @@ def main() -> int:
     section("Discrimination against truth recovery")
     print("  Does high concordance coexist with poor absolute survival prediction?")
     summary = aggregate(raw)
+    c_index_column = (
+        "c_index_harrell_integrated_hazard_mean"
+        if "c_index_harrell_integrated_hazard_mean" in summary.columns
+        else "c_index_harrell_mean"
+    )
     view = summary[
         [
             "dgp",
             "estimator_id",
-            "c_index_harrell_mean",
+            c_index_column,
             "root_mean_integrated_squared_error_mean",
             "mean_absolute_survival_error_mean",
             "calibration_error_mean",
         ]
-    ]
-    view = view.dropna(subset=["c_index_harrell_mean"])
+    ].rename(columns={c_index_column: "c_index"})
+    view = view.dropna(subset=["c_index"])
     print(
         f"\n  {'dgp':24} {'estimator':24} {'C':>7} {'RMISE':>10} {'MAE_S':>8} {'calib':>8}"
     )
@@ -144,16 +182,14 @@ def main() -> int:
         ["dgp", "root_mean_integrated_squared_error_mean"]
     ).itertuples():
         print(
-            f"  {row.dgp:24} {row.estimator_id:24} {row.c_index_harrell_mean:7.4f} "
+            f"  {row.dgp:24} {row.estimator_id:24} {row.c_index:7.4f} "
             f"{row.root_mean_integrated_squared_error_mean:10.6f} "
             f"{row.mean_absolute_survival_error_mean:8.4f} "
             f"{row.calibration_error_mean:8.4f}"
         )
 
     correlation = (
-        view[["c_index_harrell_mean", "root_mean_integrated_squared_error_mean"]]
-        .corr()
-        .iloc[0, 1]
+        view[["c_index", "root_mean_integrated_squared_error_mean"]].corr().iloc[0, 1]
     )
     print(f"\n  correlation(C-index, RMISE) across cells = {correlation:+.3f}")
     print("  A weak or positive correlation is the paper's phenomenon: ranking")
@@ -184,6 +220,76 @@ def main() -> int:
     print("\n  most demanding cells:")
     for row in worst.itertuples():
         print(f"    {row.scenario_id:38} {row.estimator_id:24} R>={row.required_R}")
+
+    section("Projected production precision at R=500")
+    precision_rows = []
+    for (scenario, estimator), block in scored.groupby(["scenario_id", "estimator_id"]):
+        values = pd.to_numeric(
+            block["root_mean_integrated_squared_error"], errors="coerce"
+        ).dropna()
+        sd = float(values.std(ddof=1)) if len(values) > 1 else float("nan")
+        precision_rows.append(
+            {
+                "scenario_id": scenario,
+                "estimator_id": estimator,
+                "pilot_replications": int(len(values)),
+                "rmise_sd": sd,
+                "expected_rmise_mcse_at_R500": (
+                    sd / math.sqrt(PRODUCTION_REPLICATIONS)
+                    if np.isfinite(sd)
+                    else float("nan")
+                ),
+            }
+        )
+    precision = pd.DataFrame.from_records(precision_rows)
+    precision.to_parquet(out / "pilot_precision.parquet", index=False)
+
+    projected_summary = _project_summary_mcse(summary, PRODUCTION_REPLICATIONS)
+    hypotheses = analyse_hypotheses(
+        projected_summary, uncertainty_draws=500, seed=20260830
+    )
+    headline = headline_metric_gap(
+        projected_summary, uncertainty_draws=500, seed=20260830
+    )
+    report = {
+        "target_replications": PRODUCTION_REPLICATIONS,
+        "rmise_mcse": {
+            "median": float(
+                precision["expected_rmise_mcse_at_R500"].median(skipna=True)
+            ),
+            "p90": float(precision["expected_rmise_mcse_at_R500"].quantile(0.90)),
+            "max": float(precision["expected_rmise_mcse_at_R500"].max(skipna=True)),
+        },
+        "hypotheses": hypotheses[
+            [
+                "hypothesis",
+                "estimate",
+                "estimate_se",
+                "estimate_ci_low",
+                "estimate_ci_high",
+                "n",
+                "supports_hypothesis",
+            ]
+        ].to_dict("records"),
+        "headline": {
+            "max_loss_quantile_se": (
+                float(headline["loss_quantile_se"].max(skipna=True))
+                if not headline.empty
+                else float("nan")
+            ),
+            "rows": int(len(headline)),
+        },
+    }
+    (out / "pilot_precision_report.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8"
+    )
+    print(
+        "  expected RMISE MCSE "
+        f"median {report['rmise_mcse']['median']:.6f}, "
+        f"p90 {report['rmise_mcse']['p90']:.6f}, "
+        f"max {report['rmise_mcse']['max']:.6f}"
+    )
+    print("  derived estimands written to " f"{out / 'pilot_precision_report.json'}")
 
     # ------------------------------------------------------------------ cost
     section("Cost")

--- a/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/aggregation.py
@@ -56,10 +56,12 @@ METRIC_COLUMNS = (
     "mean_absolute_survival_error",
     "miae_p90",
     "c_index_harrell",
+    "c_index_harrell_integrated_hazard",
     "c_index_harrell_native",
     "c_index_uno_native",
     "antolini_tie_fraction",
     "c_index_uno",
+    "c_index_uno_integrated_hazard",
     "c_index_at_tau",
     "c_index_antolini",
     "d_calibration_p",
@@ -161,7 +163,13 @@ def aggregate(
 
         records.append(record)
 
-    return pd.DataFrame.from_records(records)
+    summary = pd.DataFrame.from_records(records)
+    for suffix in ("mean", "mcse", "n"):
+        legacy = f"c_index_harrell_{suffix}"
+        explicit = f"c_index_harrell_integrated_hazard_{suffix}"
+        if legacy in summary.columns and explicit not in summary.columns:
+            summary[explicit] = summary[legacy]
+    return summary
 
 
 def paired_differences(
@@ -238,7 +246,7 @@ def paired_differences(
 def headline_metric_gap(
     summary: pd.DataFrame,
     *,
-    conventional_metric: str = "c_index_harrell_mean",
+    conventional_metric: str = "c_index_harrell_integrated_hazard_mean",
     loss: str = "root_mean_integrated_squared_error_mean",
     bins: int = 10,
     quantile: float = 0.90,

--- a/research/discrimination-not-calibration/src/survival_misspec/experiments.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/experiments.py
@@ -466,11 +466,6 @@ def run_cell(
         truth_surface = true_survival(
             scenario.dgp, grid, evaluation.truth, prepared.params
         )
-        survival_functions = None
-        predictor = getattr(fitted.model, "predict_survival_functions", None)
-        if predictor is not None:
-            survival_functions = predictor(evaluation.covariates)
-
         row.update(
             evaluate_all(
                 predicted=predicted,
@@ -483,7 +478,11 @@ def run_cell(
                 eval_time=evaluation.observed_time,
                 eval_event=evaluation.event,
                 prediction_error_times=np.asarray(prepared.ipcw_time_grid, dtype=float),
-                survival_functions=survival_functions,
+                survival_at_times=lambda requested_times: (
+                    fitted.model.predict_survival_at_times(
+                        evaluation.covariates, requested_times
+                    )
+                ),
             )
         )
         row["scored"] = True

--- a/research/discrimination-not-calibration/src/survival_misspec/hypotheses.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/hypotheses.py
@@ -21,12 +21,13 @@ CORRECTLY_SPECIFIED_REFERENCE = {
     "piecewise_exponential": "cox_ph",
 }
 PROPORTIONAL_HAZARDS_ESTIMATORS = ("cox_ph", "gradient_boosted")
-STRUCTURAL_VIOLATION_DGPS = ("aft_ln", "aft_log_logistic", "mixture_cure")
-PH_OR_BASELINE_DGPS = ("cphm", "aft_weibull", "piecewise_exponential")
+STRUCTURAL_VIOLATION_DGPS = ("aft_ln", "aft_log_logistic")
+PH_OR_BASELINE_DGPS = ("aft_weibull", "piecewise_exponential")
+H3B_STRUCTURAL_DGPS = ("mixture_cure",)
 
 RMISE = "root_mean_integrated_squared_error_mean"
 NMISE = "normalised_mise_mean"
-C_INDEX = "c_index_harrell_mean"
+C_INDEX = "c_index_harrell_integrated_hazard_mean"
 
 
 def _finite(frame: pd.DataFrame, columns: Sequence[str]) -> pd.DataFrame:
@@ -85,6 +86,7 @@ def _h1(summary: pd.DataFrame) -> dict[str, object]:
 
 def _h2(summary: pd.DataFrame) -> dict[str, object]:
     frame = _finite(summary, [C_INDEX, NMISE])
+    frame = frame[frame["effect_size"] > 0]
     records = []
     for dgp, reference in CORRECTLY_SPECIFIED_REFERENCE.items():
         block = frame[frame["dgp"] == dgp]
@@ -134,20 +136,27 @@ def _h2(summary: pd.DataFrame) -> dict[str, object]:
                 f"{dgp}:{estimator}"
                 for dgp, estimator in CORRECTLY_SPECIFIED_REFERENCE.items()
             )
+            + "; effect_size = 0 is a negative-control arm"
         ),
     )
 
 
-def _h3(summary: pd.DataFrame) -> dict[str, object]:
+def _h3_common_support(
+    summary: pd.DataFrame,
+    *,
+    hypothesis: str,
+    structural_dgps: Sequence[str],
+    baseline_dgps: Sequence[str],
+    note: str,
+) -> dict[str, object]:
     frame = _finite(summary, [RMISE])
     frame = frame[frame["effect_size"] > 0]
     frame = frame[frame["estimator_id"].isin(PROPORTIONAL_HAZARDS_ESTIMATORS)]
     frame = frame[
-        frame["dgp"].isin(STRUCTURAL_VIOLATION_DGPS)
-        | frame["dgp"].isin(PH_OR_BASELINE_DGPS)
+        frame["dgp"].isin(structural_dgps) | frame["dgp"].isin(baseline_dgps)
     ].copy()
     frame["group"] = np.where(
-        frame["dgp"].isin(STRUCTURAL_VIOLATION_DGPS), "structural", "ph_or_baseline"
+        frame["dgp"].isin(structural_dgps), "structural", "ph_or_baseline"
     )
 
     key = ["n", "target_censoring", "effect_size", "estimator_id"]
@@ -155,9 +164,7 @@ def _h3(summary: pd.DataFrame) -> dict[str, object]:
     for values, block in frame.groupby(key, dropna=False):
         structural = set(block.loc[block["group"] == "structural", "dgp"])
         ph_or_baseline = set(block.loc[block["group"] == "ph_or_baseline", "dgp"])
-        if structural == set(STRUCTURAL_VIOLATION_DGPS) and ph_or_baseline == set(
-            PH_OR_BASELINE_DGPS
-        ):
+        if structural == set(structural_dgps) and ph_or_baseline == set(baseline_dgps):
             means = block.groupby("group")[RMISE].mean()
             rows.append(
                 {
@@ -170,17 +177,16 @@ def _h3(summary: pd.DataFrame) -> dict[str, object]:
     paired = pd.DataFrame.from_records(rows)
     estimate = float(paired["difference"].mean()) if not paired.empty else float("nan")
     return _record(
-        "H3",
+        hypothesis,
         "complete_common_support_structural_minus_ph_or_baseline_rmise_beta_positive",
         estimate,
         supports=np.isfinite(estimate) and estimate > 0.0,
         n=len(paired),
         criterion="estimate > 0",
         note=(
-            "PH estimators: "
+            note
+            + "; PH estimators: "
             + ", ".join(PROPORTIONAL_HAZARDS_ESTIMATORS)
-            + "; structural DGPs: "
-            + ", ".join(STRUCTURAL_VIOLATION_DGPS)
             + "; complete structural and PH/baseline DGP sets required at each "
             + "(n, censoring, effect size, estimator) support point; "
             + "effect_size = 0 is a negative-control arm"
@@ -188,8 +194,38 @@ def _h3(summary: pd.DataFrame) -> dict[str, object]:
     )
 
 
+def _h3(summary: pd.DataFrame) -> dict[str, object]:
+    return _h3_common_support(
+        summary,
+        hypothesis="H3",
+        structural_dgps=STRUCTURAL_VIOLATION_DGPS,
+        baseline_dgps=PH_OR_BASELINE_DGPS,
+        note=(
+            "primary structural DGPs: "
+            + ", ".join(STRUCTURAL_VIOLATION_DGPS)
+            + "; primary PH/baseline DGPs: "
+            + ", ".join(PH_OR_BASELINE_DGPS)
+            + "; cphm is retained as a reference/validation DGP"
+        ),
+    )
+
+
+def _h3b(summary: pd.DataFrame) -> dict[str, object]:
+    return _h3_common_support(
+        summary,
+        hypothesis="H3b",
+        structural_dgps=H3B_STRUCTURAL_DGPS,
+        baseline_dgps=PH_OR_BASELINE_DGPS,
+        note=(
+            "sensitivity contrast for mixture_cure on its 50%/70% common support "
+            "against the shared two-normal PH/baseline DGPs"
+        ),
+    )
+
+
 def _h4(summary: pd.DataFrame) -> dict[str, object]:
     frame = _finite(summary, [RMISE, C_INDEX])
+    frame = frame[frame["effect_size"] > 0]
     low = frame[frame["target_censoring"] == 0.1]
     high = frame[frame["target_censoring"] == 0.7]
     key = ["dgp", "n", "effect_size", "estimator_id"]
@@ -219,7 +255,10 @@ def _h4(summary: pd.DataFrame) -> dict[str, object]:
         supports=np.isfinite(estimate) and estimate > 0.0,
         n=len(joined),
         criterion="estimate > 0",
-        note="paired on DGP, n, effect size and estimator; missing 10% cure cells drop out",
+        note=(
+            "paired on DGP, n, effect size and estimator; effect_size = 0 is a "
+            "negative-control arm; missing 10% cure cells drop out"
+        ),
     )
 
 
@@ -262,7 +301,13 @@ def _with_uncertainty(
     }
     for _ in range(uncertainty_draws):
         sampled = _metric_draw(summary, rng, (C_INDEX, RMISE, NMISE))
-        for record in (_h1(sampled), _h2(sampled), _h3(sampled), _h4(sampled)):
+        for record in (
+            _h1(sampled),
+            _h2(sampled),
+            _h3(sampled),
+            _h3b(sampled),
+            _h4(sampled),
+        ):
             draws[str(record["hypothesis"])].append(float(record["estimate"]))
 
     out = point.copy()
@@ -299,7 +344,7 @@ def analyse_hypotheses(
     if missing:
         raise ValueError(f"hypothesis analysis missing columns: {missing}")
     point = pd.DataFrame.from_records(
-        [_h1(summary), _h2(summary), _h3(summary), _h4(summary)]
+        [_h1(summary), _h2(summary), _h3(summary), _h3b(summary), _h4(summary)]
     )
     return _with_uncertainty(
         point,

--- a/research/discrimination-not-calibration/src/survival_misspec/metrics.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/metrics.py
@@ -475,15 +475,17 @@ def _survival_from_functions(
 def expected_mortality(
     predicted: NDArray[np.float64], grid: NDArray[np.float64]
 ) -> NDArray[np.float64]:
-    r"""One risk score, computed the same way for every model.
+    r"""One integrated-hazard risk score, computed the same way for every model.
 
     .. math::
 
-        r_i = \sum_k \hat H(t_k \mid x_i)
-            = -\sum_k \log \hat S(t_k \mid x_i)
+        r_i = \int_0^\tau \hat H(t \mid x_i)\,dt
+            = \int_0^\tau -\log \hat S(t \mid x_i)\,dt
 
-    the summed cumulative hazard over the evaluation grid — the "expected
-    mortality" transformation of Ishwaran et al. (2008).
+    the trapezoid-rule integral of the cumulative hazard over the evaluation
+    grid. It is the same monotone-in-risk survival-curve transformation used
+    for every estimator, and is reported explicitly as the integrated-hazard
+    Harrell/Uno C-index.
 
     **Why this exists.** Sonabend et al. (2022) identify three forms of
     C-hacking, and the third is evaluating distribution predictions with a
@@ -516,6 +518,9 @@ def d_calibration(
     event: NDArray[np.bool_],
     n_bins: int = 10,
     survival_functions: Sequence[Callable[[float], float]] | None = None,
+    survival_at_times: (
+        Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
+    ) = None,
 ) -> dict[str, float]:
     """Distributional calibration, after Haider et al. (2020).
 
@@ -548,11 +553,12 @@ def d_calibration(
     proof do not cancel and buckets spanning the flat region take a larger share
     than they should -- so the statistic is inflated and the test over-rejects.
     Two of this study's four estimators, the random survival forest and gradient
-    boosting, predict step functions with exactly such flat regions. Some part
-    of their poorer D-calibration is therefore an artefact of the measure rather
-    than evidence about the model, and the paper must say so rather than read
-    the rejection at face value. The parametric estimators are unaffected: their
-    curves are smooth and strictly decreasing.
+    boosting, predict step functions with exactly such flat regions. Cox curves
+    also inherit the Breslow baseline's step structure. Some part of a poorer
+    D-calibration score for these estimators is therefore an artefact of the
+    measure rather than evidence about the model, and the paper must say so
+    rather than read the rejection at face value. A smooth parametric survival
+    curve, such as Weibull AFT, is not affected in the same way.
 
     Censoring works the other way, smoothing the bucket proportions and raising
     the p-value, so the test is conservative under heavy censoring -- which is
@@ -573,7 +579,9 @@ def d_calibration(
     observed = np.where(beyond, horizon, observed)
     had_event = had_event & ~beyond
 
-    if survival_functions is None:
+    if survival_at_times is not None:
+        survival_at_observed = np.clip(survival_at_times(observed), 0.0, 1.0)
+    elif survival_functions is None:
         survival_at_observed = _survival_at(predicted, grid, observed)
     else:
         survival_at_observed = _survival_from_functions(survival_functions, observed)
@@ -622,6 +630,9 @@ def antolini_concordance(
     max_events: int = 800,
     seed: int = 0,
     survival_functions: Sequence[Callable[[float], float]] | None = None,
+    survival_at_times: (
+        Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
+    ) = None,
 ) -> dict[str, float]:
     r"""Time-dependent concordance, after Antolini et al. (2005), Equation 11.
 
@@ -696,7 +707,11 @@ def antolini_concordance(
         if not later.any():
             continue
         event_time = float(observed[subject])
-        if survival_functions is None:
+        if survival_at_times is not None:
+            at_event = np.clip(
+                survival_at_times(np.full(observed.shape, event_time)), 0.0, 1.0
+            )
+        elif survival_functions is None:
             at_event = _survival_at_common_time(predicted, grid, event_time, step_like)
         else:
             at_event = _survival_from_functions(
@@ -735,6 +750,9 @@ def evaluate_all(
     eval_event: NDArray[np.bool_],
     prediction_error_times: NDArray[np.float64] | None = None,
     survival_functions: Sequence[Callable[[float], float]] | None = None,
+    survival_at_times: (
+        Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
+    ) = None,
 ) -> dict[str, Any]:
     """Every metric for one fitted model, on an **independent** evaluation sample.
 
@@ -760,8 +778,13 @@ def evaluate_all(
     # risk is the third form of C-hacking in Sonabend et al. (2022): three
     # different mathematical objects compared with one measure.
     common = expected_mortality(predicted, grid)
-    results.update(
-        discrimination(common, train_time, train_event, eval_time, eval_event, tau)
+    integrated_hazard = discrimination(
+        common, train_time, train_event, eval_time, eval_event, tau
+    )
+    results.update(integrated_hazard)
+    results["c_index_harrell_integrated_hazard"] = integrated_hazard["c_index_harrell"]
+    results["c_index_uno_integrated_hazard"] = integrated_hazard.get(
+        "c_index_uno", float("nan")
     )
 
     # The native score, reported separately and named as such. Sonabend et al.
@@ -806,6 +829,7 @@ def evaluate_all(
             eval_time,
             eval_event,
             survival_functions=survival_functions,
+            survival_at_times=survival_at_times,
         )
     )
     results.update(
@@ -815,6 +839,7 @@ def evaluate_all(
             eval_time,
             eval_event,
             survival_functions=survival_functions,
+            survival_at_times=survival_at_times,
         )
     )
 

--- a/research/discrimination-not-calibration/src/survival_misspec/validation.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/validation.py
@@ -371,6 +371,29 @@ def verify_lock(
             "commit: " + ", ".join(current.git_dirty_files[:10])
         )
 
+    gate_evidence = lock.get("gate_evidence", {})
+    if strict_commit:
+        if not isinstance(gate_evidence, Mapping):
+            problems.append("lock gate_evidence is not a mapping")
+        else:
+            for gate in ("ipcw_availability", "grid_convergence"):
+                record = gate_evidence.get(gate)
+                if not isinstance(record, Mapping):
+                    problems.append(f"lock is missing {gate} gate evidence")
+                    continue
+                if record.get("status") != "PASS":
+                    problems.append(f"{gate} gate did not record status PASS")
+                if record.get("study_hash") != study.hash:
+                    problems.append(
+                        f"{gate} gate study_hash={record.get('study_hash')} "
+                        f"but current={study.hash}"
+                    )
+                if record.get("git_commit") != locked_provenance.get("git_commit"):
+                    problems.append(
+                        f"{gate} gate commit={record.get('git_commit')} "
+                        "does not match the lock commit"
+                    )
+
     if current.version_metadata_stale:
         problems.append(
             f"installed gen_surv metadata ({current.gen_surv_version}) disagrees "

--- a/research/discrimination-not-calibration/tests/test_distribution_metrics.py
+++ b/research/discrimination-not-calibration/tests/test_distribution_metrics.py
@@ -149,6 +149,33 @@ def test_d_calibration_can_use_native_step_functions() -> None:
     assert outcome["d_calibration_statistic"] == pytest.approx(statistic)
 
 
+def test_d_calibration_prefers_exact_time_callback() -> None:
+    grid = np.array([0.0, 1.0, 2.0])
+    predicted = np.array([[1.0, 0.2, 0.2]])
+    observed = np.array([0.5])
+    calls = []
+
+    def exact(times: np.ndarray) -> np.ndarray:
+        calls.append(times.copy())
+        return np.array([0.8])
+
+    outcome = d_calibration(
+        predicted,
+        grid,
+        observed,
+        np.ones(1, dtype=bool),
+        survival_at_times=exact,
+    )
+
+    expected = np.zeros(10)
+    expected[8] = 1.0
+    uniform = np.full(10, 0.1)
+    statistic = float(((expected - uniform) ** 2 / uniform).sum())
+    assert outcome["d_calibration_statistic"] == pytest.approx(statistic)
+    assert len(calls) == 1
+    np.testing.assert_allclose(calls[0], observed)
+
+
 def test_antolini_agrees_with_a_known_ranking_when_hazards_are_proportional() -> None:
     """Under proportional hazards the ranking does not depend on the horizon.
 
@@ -272,6 +299,34 @@ def test_antolini_can_use_native_step_functions() -> None:
 
     assert outcome["antolini_pairs"] == 1
     assert outcome["c_index_antolini"] == pytest.approx(1.0)
+
+
+def test_antolini_prefers_exact_time_callback() -> None:
+    grid = np.array([0.0, 1.0, 2.0])
+    predicted = np.array(
+        [
+            [1.0, 0.9, 0.9],
+            [1.0, 0.1, 0.1],
+        ]
+    )
+    calls = []
+
+    def exact(times: np.ndarray) -> np.ndarray:
+        calls.append(times.copy())
+        return np.array([0.2, 0.8])
+
+    outcome = antolini_concordance(
+        predicted,
+        grid,
+        np.array([0.5, 1.5]),
+        np.array([True, True]),
+        survival_at_times=exact,
+    )
+
+    assert outcome["antolini_pairs"] == 1
+    assert outcome["c_index_antolini"] == pytest.approx(1.0)
+    assert len(calls) == 1
+    np.testing.assert_allclose(calls[0], np.array([0.5, 0.5]))
 
 
 def test_truth_recovery_reports_horizon_normalised_squared_loss() -> None:

--- a/research/discrimination-not-calibration/tests/test_hypotheses.py
+++ b/research/discrimination-not-calibration/tests/test_hypotheses.py
@@ -36,7 +36,7 @@ def _summary() -> pd.DataFrame:
                         "effect_size": 0.5,
                         "estimator_id": estimator,
                         "misspecification": misspecification,
-                        "c_index_harrell_mean": c_index,
+                        "c_index_harrell_integrated_hazard_mean": c_index,
                         "normalised_mise_mean": rmise**2,
                         "root_mean_integrated_squared_error_mean": rmise,
                     }
@@ -47,7 +47,7 @@ def _summary() -> pd.DataFrame:
 def test_hypotheses_are_machine_readable() -> None:
     hypotheses = analyse_hypotheses(_summary(), uncertainty_draws=20, seed=1)
 
-    assert set(hypotheses["hypothesis"]) == {"H1", "H2", "H3", "H4"}
+    assert set(hypotheses["hypothesis"]) == {"H1", "H2", "H3", "H3b", "H4"}
     assert hypotheses["estimand"].notna().all()
     assert hypotheses["criterion"].notna().all()
     assert {
@@ -80,7 +80,7 @@ def test_h1_uses_spearman_not_pearson() -> None:
             "effect_size": [0.5] * 4,
             "estimator_id": ["cox_ph"] * 4,
             "misspecification": ["non-proportional hazards"] * 4,
-            "c_index_harrell_mean": [0.60, 0.90, 0.70, 0.80],
+            "c_index_harrell_integrated_hazard_mean": [0.60, 0.90, 0.70, 0.80],
             "normalised_mise_mean": [0.01, 0.0121, 0.0144, 0.25],
             "root_mean_integrated_squared_error_mean": [0.10, 0.11, 0.12, 0.50],
         }
@@ -93,12 +93,12 @@ def test_h1_uses_spearman_not_pearson() -> None:
     )
 
     assert h1["estimate"] == pytest.approx(
-        summary["c_index_harrell_mean"].corr(
+        summary["c_index_harrell_integrated_hazard_mean"].corr(
             summary["root_mean_integrated_squared_error_mean"], method="spearman"
         )
     )
     assert h1["estimate"] != pytest.approx(
-        summary["c_index_harrell_mean"].corr(
+        summary["c_index_harrell_integrated_hazard_mean"].corr(
             summary["root_mean_integrated_squared_error_mean"], method="pearson"
         )
     )
@@ -109,7 +109,8 @@ def test_h3_and_h4_use_common_support() -> None:
         "hypothesis"
     )
 
-    assert hypotheses.loc["H3", "n"] == 4
+    assert hypotheses.loc["H3", "n"] == 6
+    assert hypotheses.loc["H3b", "n"] == 4
     assert hypotheses.loc["H4", "n"] == 15
     assert "common_support" in hypotheses.loc["H3", "estimand"]
     assert "common_support" in hypotheses.loc["H4", "estimand"]
@@ -144,10 +145,26 @@ def test_h1_excludes_null_effect_cells_from_misspecification_primary() -> None:
     assert "effect_size > 0" in h1["note"]
 
 
+def test_h2_and_h4_exclude_null_effect_cells_from_primary() -> None:
+    summary = _summary()
+    null_rows = summary.copy()
+    null_rows["scenario_id"] = null_rows["scenario_id"] + "__null"
+    null_rows["effect_size"] = 0.0
+    combined = pd.concat([summary, null_rows], ignore_index=True)
+    hypotheses = analyse_hypotheses(combined, uncertainty_draws=0).set_index(
+        "hypothesis"
+    )
+
+    assert hypotheses.loc["H2", "n"] == 18
+    assert hypotheses.loc["H4", "n"] == 15
+    assert "negative-control arm" in hypotheses.loc["H2", "note"]
+    assert "negative-control arm" in hypotheses.loc["H4", "note"]
+
+
 def test_h3_requires_complete_structural_and_baseline_support() -> None:
     summary = _summary()
     incomplete = summary[
-        ~((summary["dgp"] == "mixture_cure") & (summary["target_censoring"] == 0.5))
+        ~((summary["dgp"] == "aft_ln") & (summary["target_censoring"] == 0.5))
     ]
 
     h3 = (
@@ -156,5 +173,5 @@ def test_h3_requires_complete_structural_and_baseline_support() -> None:
         .loc["H3"]
     )
 
-    assert h3["n"] == 2
+    assert h3["n"] == 4
     assert "complete structural" in h3["note"]

--- a/research/discrimination-not-calibration/tests/test_pipeline.py
+++ b/research/discrimination-not-calibration/tests/test_pipeline.py
@@ -514,7 +514,7 @@ def test_compact_raw_writes_one_deterministic_file(tmp_path) -> None:
 def test_headline_metric_gap_operationalises_the_primary_claim() -> None:
     summary = pd.DataFrame(
         {
-            "c_index_harrell_mean": [0.6, 0.61, 0.7, 0.71],
+            "c_index_harrell_integrated_hazard_mean": [0.6, 0.61, 0.7, 0.71],
             "root_mean_integrated_squared_error_mean": [0.05, 0.20, 0.04, 0.30],
             "root_mean_integrated_squared_error_mcse": [0.001] * 4,
         }
@@ -523,8 +523,8 @@ def test_headline_metric_gap_operationalises_the_primary_claim() -> None:
     headline = headline_metric_gap(summary, bins=2, quantile=0.9)
 
     assert list(headline["metric"]) == [
-        "c_index_harrell_mean",
-        "c_index_harrell_mean",
+        "c_index_harrell_integrated_hazard_mean",
+        "c_index_harrell_integrated_hazard_mean",
     ]
     assert headline["loss_quantile"].max() == pytest.approx(0.274)
     assert "loss_quantile_se" in headline.columns

--- a/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
+++ b/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
@@ -15,7 +15,9 @@ from survival_misspec.config import (
     MetricsConfig,
     ScenarioConfig,
     StudyConfig,
+    content_hash,
 )
+from survival_misspec.validation import capture_provenance
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -29,10 +31,29 @@ def _load_script(name: str):
     return module
 
 
+def _metadata(study: StudyConfig, **extra: object) -> dict[str, object]:
+    provenance = capture_provenance()
+    return {
+        "study_hash": study.hash,
+        "git_commit": provenance.git_commit,
+        "git_tree_clean": True,
+        "n_replications_planned": study.n_replications,
+        "scenario_design_hash": content_hash(
+            {scenario.scenario_id: scenario.hash for scenario in study.scenarios}
+        ),
+        "estimator_design_hash": content_hash(
+            {estimator.estimator_id: estimator.hash for estimator in study.estimators}
+        ),
+        "metrics_hash": study.metrics.hash,
+        **extra,
+    }
+
+
 def test_headline_bootstrap_is_deterministic_under_fixed_seed() -> None:
     summary = pd.DataFrame(
         {
             "c_index_harrell_mean": [0.60, 0.61, 0.70, 0.71],
+            "c_index_harrell_integrated_hazard_mean": [0.60, 0.61, 0.70, 0.71],
             "root_mean_integrated_squared_error_mean": [0.05, 0.20, 0.04, 0.30],
             "root_mean_integrated_squared_error_mcse": [0.002, 0.003, 0.002, 0.004],
         }
@@ -55,6 +76,7 @@ def test_headline_bootstrap_se_is_not_divided_by_number_of_draws() -> None:
     summary = pd.DataFrame(
         {
             "c_index_harrell_mean": [0.60, 0.61, 0.70, 0.71],
+            "c_index_harrell_integrated_hazard_mean": [0.60, 0.61, 0.70, 0.71],
             "root_mean_integrated_squared_error_mean": [0.05, 0.20, 0.04, 0.30],
             "root_mean_integrated_squared_error_mcse": [0.002, 0.003, 0.002, 0.004],
         }
@@ -127,6 +149,7 @@ def test_grid_convergence_pass_fail_uses_preregistered_rmise_tolerance() -> None
         {
             "n_time_points": [51, 801],
             "rmise_absolute_difference": [0.0021, 0.0],
+            "c_index_harrell_integrated_hazard_absolute_difference": [0.001, 0.0],
         }
     )
 
@@ -135,6 +158,7 @@ def test_grid_convergence_pass_fail_uses_preregistered_rmise_tolerance() -> None
     )
     assert grid.grid_convergence_passes(frame, reference_grid=801, rmise_epsilon=0.003)
     assert grid.maximum_rmise_difference(frame, 801) == pytest.approx(0.0021)
+    assert grid.maximum_c_index_difference(frame, 801) == pytest.approx(0.001)
 
 
 def test_grid_convergence_selects_worst_cells_from_summary() -> None:
@@ -171,29 +195,91 @@ def test_freeze_gate_evidence_records_passed_artifact_hashes(tmp_path) -> None:
     freeze = _load_script("freeze_experiment.py")
     ipcw = tmp_path / "ipcw.parquet"
     grid = tmp_path / "grid.parquet"
+    summary = tmp_path / "summary.parquet"
+    study = StudyConfig(
+        paper_id="p",
+        master_seed=1,
+        n_replications=10,
+        scenarios=(
+            ScenarioConfig("s1", "cphm", 100, 0.3, 0.5, {}),
+            ScenarioConfig("s2", "cphm", 100, 0.3, 0.5, {}),
+        ),
+        estimators=(EstimatorConfig("cox_ph", "cox_ph"),),
+        metrics=MetricsConfig(0.8, 11, (0.5,), ("mise",)),
+    )
+    ipcw_metadata = _metadata(
+        study,
+        audited_replications=10,
+        minimum_availability_threshold=0.95,
+    )
     pd.DataFrame(
-        {
-            "scenario_id": ["s1", "s2"],
-            "feasible": [True, False],
-            "availability": [0.96, np.nan],
-        }
+        [
+            {
+                "scenario_id": "s1",
+                "scenario_hash": study.scenarios[0].hash,
+                "feasible": True,
+                "availability": 0.96,
+                "attempted": 10,
+                **ipcw_metadata,
+            },
+            {
+                "scenario_id": "s2",
+                "scenario_hash": study.scenarios[1].hash,
+                "feasible": False,
+                "availability": np.nan,
+                "attempted": 0,
+                **ipcw_metadata,
+            },
+        ]
     ).to_parquet(ipcw, index=False)
     pd.DataFrame(
         {
-            "n_time_points": [51, 801],
-            "reference_n_time_points": [801, 801],
-            "rmise_absolute_difference": [0.001, 0.0],
+            "scenario_id": ["s1", "s2"],
+            "estimator_id": ["cox_ph", "cox_ph"],
+            "root_mean_integrated_squared_error_mean": [0.9, 0.1],
         }
-    ).to_parquet(grid, index=False)
+    ).to_parquet(summary, index=False)
+    grid_metadata = _metadata(
+        study,
+        audited_replications=10,
+        rmise_epsilon=0.002,
+        c_index_epsilon=0.002,
+        selected_summary_sha256=freeze.file_sha256(summary),
+        top_cells=1,
+        loss_column="",
+    )
+    grid_rows = []
+    for replication_id in range(10):
+        for points, rmise_difference in ((51, 0.001), (801, 0.0)):
+            grid_rows.append(
+                {
+                    "scenario_id": "s1",
+                    "scenario_hash": study.scenarios[0].hash,
+                    "estimator_id": "cox_ph",
+                    "estimator_hash": study.estimators[0].hash,
+                    "replication_id": replication_id,
+                    "n_time_points": points,
+                    "reference_n_time_points": 801,
+                    "rmise_absolute_difference": rmise_difference,
+                    "c_index_harrell_integrated_hazard_absolute_difference": (
+                        0.001 if points == 51 else 0.0
+                    ),
+                    **grid_metadata,
+                }
+            )
+    pd.DataFrame(grid_rows).to_parquet(grid, index=False)
 
-    ipcw_evidence = freeze._ipcw_gate_evidence(ipcw, 0.95)
-    grid_evidence = freeze._grid_gate_evidence(grid, 0.002)
+    ipcw_evidence = freeze._ipcw_gate_evidence(ipcw, 0.95, study)
+    grid_evidence = freeze._grid_gate_evidence(
+        grid, 0.002, 0.002, study, summary, 1, 10
+    )
 
     assert ipcw_evidence["status"] == "PASS"
     assert ipcw_evidence["minimum_availability"] == pytest.approx(0.96)
     assert len(ipcw_evidence["sha256"]) == 64
     assert grid_evidence["status"] == "PASS"
     assert grid_evidence["maximum_rmise_difference"] == pytest.approx(0.001)
+    assert grid_evidence["maximum_c_index_difference"] == pytest.approx(0.001)
     assert len(grid_evidence["sha256"]) == 64
 
 

--- a/research/discrimination-not-calibration/tests/test_provenance.py
+++ b/research/discrimination-not-calibration/tests/test_provenance.py
@@ -274,6 +274,16 @@ def test_lock_hash_includes_gate_evidence(tmp_path) -> None:
     assert first.lock_hash != second.lock_hash
 
 
+def test_strict_lock_verification_requires_passed_gate_evidence(tmp_path) -> None:
+    study = _study()
+    _write(tmp_path, study)
+
+    problems = verify_lock(tmp_path / "experiment_lock.json", study, strict_commit=True)
+
+    assert any("ipcw_availability gate evidence" in problem for problem in problems)
+    assert any("grid_convergence gate evidence" in problem for problem in problems)
+
+
 def test_lock_verification_requires_prepared_scenarios(tmp_path) -> None:
     study = _study()
     path = tmp_path / "experiment_lock.json"


### PR DESCRIPTION
## Summary
- require production freeze gate artifacts to match the current study hash, commit, scenario/estimator/metrics hashes, selected cells, thresholds, and planned replication counts
- name the primary C-index as integrated-hazard Harrell/Uno C-index while preserving legacy aliases for existing plots
- revise H2/H3/H4 primary estimands, split mixture cure into H3b sensitivity, and add production R=500 precision reporting
- use the adapter-level exact-time survival callback for distributional metrics across estimators

## Validation
- poetry run pre-commit run --all-files
- poetry run pytest
- poetry run mkdocs build --strict
- poetry run python research\\discrimination-not-calibration\\scripts\\check_grid_convergence.py --config research\\discrimination-not-calibration\\config --summary research\\discrimination-not-calibration\\results\\processed\\summary.parquet --top-cells 10 --replications 10 --rmise-epsilon 0.002 --c-index-epsilon 0.002
  - max RMISE diff: 0.000710
  - max integrated-hazard C-index diff: 0.000479
- poetry run python research\\discrimination-not-calibration\\scripts\\audit_ipcw_availability.py --config research\\discrimination-not-calibration\\config --minimum-availability 0.95
  - scenarios: 216
  - min availability: 0.996
- strict local lock verification: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the research freeze contract so stale gate artifacts no longer pass validation, and adds production precision reporting. Gate artifacts now must match the current study configuration, and the primary concordance metric is explicitly named as the integrated-hazard C-index.

**Freeze contract**
- `freeze_experiment.py` fails when gate artifacts lack required metadata or do not match the current study, scenario, estimator, or metrics hashes, selected cells, thresholds, and replication counts.
- `check_grid_convergence.py` and `audit_ipcw_availability.py` now embed that metadata and add a C-index stability check against the finest grid.
- `verify_lock` requires passed gate evidence from both gates when strict commit verification is enabled.

**Estimands and precision**
- Primary Harrell/Uno concordance is renamed to `c_index_harrell_integrated_hazard` and `c_index_uno_integrated_hazard`; the legacy `c_index_harrell` alias is preserved.
- D-calibration and Antolini metrics now use an adapter-level exact-time survival callback when available, instead of grid interpolation.
- H2, H3, and H4 exclude the effect-size-zero negative-control arm; H3 splits into H3 and H3b, with mixture cure moved to H3b sensitivity.
- `run_pilot.py` writes a production R=500 precision report with projected RMISE MCSE, hypothesis draws, and headline metric-gap uncertainty.

<sup>Written for commit 1b5e119af8b8fd8d59316619b190a96644e6b335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

