### PR TITLE
Batch exact-time Antolini scoring

### DIFF
--- a/research/discrimination-not-calibration/src/survival_misspec/experiments.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/experiments.py
@@ -483,6 +483,11 @@ def run_cell(
                         evaluation.covariates, requested_times
                     )
                 ),
+                survival_matrix_at_times=lambda requested_times: (
+                    fitted.model.predict_survival(
+                        evaluation.covariates, requested_times
+                    )
+                ),
             )
         )
         row["scored"] = True

--- a/research/discrimination-not-calibration/src/survival_misspec/metrics.py
+++ b/research/discrimination-not-calibration/src/survival_misspec/metrics.py
@@ -633,6 +633,9 @@ def antolini_concordance(
     survival_at_times: (
         Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
     ) = None,
+    survival_matrix_at_times: (
+        Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
+    ) = None,
 ) -> dict[str, float]:
     r"""Time-dependent concordance, after Antolini et al. (2005), Equation 11.
 
@@ -698,6 +701,13 @@ def antolini_concordance(
         rng = np.random.default_rng(seed)
         event_index = rng.choice(event_index, size=max_events, replace=False)
 
+    exact_matrix = None
+    exact_columns: dict[float, int] = {}
+    if survival_matrix_at_times is not None:
+        exact_times = np.unique(observed[event_index])
+        exact_matrix = np.clip(survival_matrix_at_times(exact_times), 0.0, 1.0)
+        exact_columns = {float(value): index for index, value in enumerate(exact_times)}
+
     concordant = 0.0
     tied = 0.0
     comparable = 0.0
@@ -707,7 +717,9 @@ def antolini_concordance(
         if not later.any():
             continue
         event_time = float(observed[subject])
-        if survival_at_times is not None:
+        if exact_matrix is not None:
+            at_event = exact_matrix[:, exact_columns[event_time]]
+        elif survival_at_times is not None:
             at_event = np.clip(
                 survival_at_times(np.full(observed.shape, event_time)), 0.0, 1.0
             )
@@ -751,6 +763,9 @@ def evaluate_all(
     prediction_error_times: NDArray[np.float64] | None = None,
     survival_functions: Sequence[Callable[[float], float]] | None = None,
     survival_at_times: (
+        Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
+    ) = None,
+    survival_matrix_at_times: (
         Callable[[NDArray[np.float64]], NDArray[np.float64]] | None
     ) = None,
 ) -> dict[str, Any]:
@@ -840,6 +855,7 @@ def evaluate_all(
             eval_event,
             survival_functions=survival_functions,
             survival_at_times=survival_at_times,
+            survival_matrix_at_times=survival_matrix_at_times,
         )
     )
 

--- a/research/discrimination-not-calibration/tests/test_distribution_metrics.py
+++ b/research/discrimination-not-calibration/tests/test_distribution_metrics.py
@@ -329,6 +329,50 @@ def test_antolini_prefers_exact_time_callback() -> None:
     np.testing.assert_allclose(calls[0], np.array([0.5, 0.5]))
 
 
+def test_antolini_prefers_batched_exact_time_matrix() -> None:
+    grid = np.array([0.0, 1.0, 2.0])
+    predicted = np.array(
+        [
+            [1.0, 0.9, 0.9],
+            [1.0, 0.1, 0.1],
+            [1.0, 0.1, 0.1],
+        ]
+    )
+    time = np.array([0.5, 1.0, 1.5])
+    event = np.array([True, True, True])
+    matrix_calls = []
+    vector_calls = []
+
+    def matrix(times: np.ndarray) -> np.ndarray:
+        matrix_calls.append(times.copy())
+        return np.array(
+            [
+                [0.2, 0.2, 0.2],
+                [0.8, 0.2, 0.2],
+                [0.8, 0.8, 0.2],
+            ]
+        )
+
+    def vector(times: np.ndarray) -> np.ndarray:
+        vector_calls.append(times.copy())
+        return np.zeros_like(times, dtype=float)
+
+    outcome = antolini_concordance(
+        predicted,
+        grid,
+        time,
+        event,
+        survival_at_times=vector,
+        survival_matrix_at_times=matrix,
+    )
+
+    assert outcome["antolini_pairs"] == 3
+    assert outcome["c_index_antolini"] == pytest.approx(1.0)
+    assert len(matrix_calls) == 1
+    np.testing.assert_allclose(matrix_calls[0], time)
+    assert vector_calls == []
+
+
 def test_truth_recovery_reports_horizon_normalised_squared_loss() -> None:
     grid = np.linspace(0.0, 2.0, 21)
     truth = np.tile(np.exp(-grid), (1, 1))


### PR DESCRIPTION
## Summary
- batch Antolini exact-time survival evaluation over selected event times instead of repeatedly calling per-time prediction
- keep D-calibration on the vector exact-time callback and use the batched matrix callback only for Antolini
- add a regression test proving the batched callback is preferred over repeated vector calls

## Validation
- poetry run pre-commit run --all-files
- poetry run pytest
- poetry run mkdocs build --strict
- production-style RSF cell timing: scored=True in 6.59s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches exact-time Antolini survival evaluation so the model predicts survival for all event times in one call instead of calling per-time prediction repeatedly. Keeps D-calibration on the vector callback and uses the new batched matrix callback only for Antolini.

- Adds a regression test proving the batched callback is preferred when both callbacks are supplied.
- `evaluate_all` and `antolini_concordance` now accept `survival_matrix_at_times` and pass it through to Antolini scoring.
- Production-style RSF cell scoring completes in 6.59s with this change.

<sup>Written for commit dce7ce63f287d763d8079e61d82f1112e793a6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

