### PR TITLE
Freeze grid audit cell selection

### DIFF
--- a/research/discrimination-not-calibration/README.md
+++ b/research/discrimination-not-calibration/README.md
@@ -66,10 +66,10 @@ without matching it:
 python scripts/make_config.py --production
 python scripts/check_ipcw_availability.py --minimum-availability 0.95
 python scripts/check_grid_convergence.py \
-    --summary results/processed/summary.parquet \
-    --top-cells 10 \
+    --audit-cells protocol/grid_audit_cells.json \
     --replications 10 \
-    --rmise-epsilon 0.002
+    --rmise-epsilon 0.002 \
+    --c-index-epsilon 0.002
 python scripts/freeze_experiment.py --out protocol/experiment_lock.json
 python scripts/run_simulation.py \
     --out results/raw/production.parquet \
@@ -83,6 +83,9 @@ python scripts/analyze_hypotheses.py --macros paper/macros/hypotheses.tex
 source file. The lock records the commit that produced it; committing the lock
 would necessarily change the current commit and defeat strict commit
 verification.
+`protocol/grid_audit_cells.json` is committed because it is part of the frozen
+pre-production gate: it names the exact scenario-estimator cells used by the
+grid-convergence audit.
 
 ## Design decisions worth knowing before reading the code
 

--- a/research/discrimination-not-calibration/protocol/grid_audit_cells.json
+++ b/research/discrimination-not-calibration/protocol/grid_audit_cells.json
@@ -1,0 +1,109 @@
+{
+  "version": 1,
+  "selection_rationale": "Frozen before production from the latest processed pilot cell-level loss summary available before freeze. Cells are the ten largest finite mise_mean scenario-estimator cells in the production design support; the committed list is the gate input, not the generated summary file.",
+  "selection_metric": "mise_mean",
+  "source_summary": "results/processed/summary.parquet",
+  "source_summary_role": "pre-freeze pilot selection record only; not required to reproduce the production gate",
+  "cells": [
+    {
+      "scenario_id": "aft_log_logistic__n250__c70__b0p50",
+      "scenario_hash": "803a830cca31a20a",
+      "estimator_id": "random_survival_forest",
+      "estimator_hash": "f37d5950d3aaeac4",
+      "dgp": "aft_log_logistic",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n250__c70__b0p50",
+      "scenario_hash": "803a830cca31a20a",
+      "estimator_id": "gradient_boosted",
+      "estimator_hash": "6bb21fdf3800258c",
+      "dgp": "aft_log_logistic",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n1000__c70__b0p50",
+      "scenario_hash": "e06e0781f73adec7",
+      "estimator_id": "random_survival_forest",
+      "estimator_hash": "f37d5950d3aaeac4",
+      "dgp": "aft_log_logistic",
+      "n": 1000,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n250__c70__b0p50",
+      "scenario_hash": "803a830cca31a20a",
+      "estimator_id": "cox_ph",
+      "estimator_hash": "8f293573d7ad27e6",
+      "dgp": "aft_log_logistic",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n250__c30__b0p50",
+      "scenario_hash": "cd8afdef6c4fd984",
+      "estimator_id": "gradient_boosted",
+      "estimator_hash": "6bb21fdf3800258c",
+      "dgp": "aft_log_logistic",
+      "n": 250,
+      "target_censoring": 0.3,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n1000__c70__b0p50",
+      "scenario_hash": "e06e0781f73adec7",
+      "estimator_id": "gradient_boosted",
+      "estimator_hash": "6bb21fdf3800258c",
+      "dgp": "aft_log_logistic",
+      "n": 1000,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_log_logistic__n1000__c70__b0p50",
+      "scenario_hash": "e06e0781f73adec7",
+      "estimator_id": "cox_ph",
+      "estimator_hash": "8f293573d7ad27e6",
+      "dgp": "aft_log_logistic",
+      "n": 1000,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_ln__n250__c70__b0p50",
+      "scenario_hash": "2fafadc6699d1af6",
+      "estimator_id": "random_survival_forest",
+      "estimator_hash": "f37d5950d3aaeac4",
+      "dgp": "aft_ln",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_ln__n250__c70__b0p50",
+      "scenario_hash": "2fafadc6699d1af6",
+      "estimator_id": "gradient_boosted",
+      "estimator_hash": "6bb21fdf3800258c",
+      "dgp": "aft_ln",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    },
+    {
+      "scenario_id": "aft_weibull__n250__c70__b0p50",
+      "scenario_hash": "8b9501a8fde967a4",
+      "estimator_id": "gradient_boosted",
+      "estimator_hash": "6bb21fdf3800258c",
+      "dgp": "aft_weibull",
+      "n": 250,
+      "target_censoring": 0.7,
+      "effect_size": 0.5
+    }
+  ]
+}

--- a/research/discrimination-not-calibration/protocol/preregistration.md
+++ b/research/discrimination-not-calibration/protocol/preregistration.md
@@ -45,9 +45,10 @@ survival curve — a quantity no evaluation on observed data can compute, becaus
 observed data do not contain the truth.
 
 The contribution is therefore a **measurement, not a phenomenon**: how much
-truth-error is consistent with an apparently acceptable value of each
-conventional metric. The unit of interest is the metric, not the estimator; an
-estimator ranking is a by-product.
+truth-error is consistent with apparently acceptable conventional survival
+metrics. The headline quantitative illustration is prespecified for
+integrated-hazard Harrell C-index; other conventional metrics are secondary
+descriptive checks unless explicitly tabulated.
 
 ## 2. Hypotheses
 
@@ -57,26 +58,37 @@ and H4 concern where it bites and how far it goes.
 
 **H1.** Concordance and recovery of the true survival function are weakly
 related across misspecified scenarios. Formally, the correlation between the
-C-index and RMISE across non-null misspecified cells has absolute Spearman rank
-correlation below 0.30. Pearson correlation is reported as a sensitivity
-summary, not as the decision rule. The $\beta=0$ cells are a negative-control
-arm rather than primary PH-violation evidence.
+integrated-hazard Harrell C-index and RMISE across non-null misspecified cells
+has absolute Spearman rank correlation below 0.30. Pearson correlation is
+reported as a sensitivity summary, not as the decision rule. The $\beta=0$
+cells are a negative-control arm rather than primary PH-violation evidence.
 
-**H2.** There exist scenarios in which an estimator's concordance is at or above
-that of a correctly specified reference while its nMISE is larger by an order of
-magnitude.
+**H2.** There exist non-null scenarios in which an estimator's integrated-hazard
+Harrell C-index is at or above that of a correctly specified reference
+while its nMISE is larger by an order of magnitude. The $\beta=0$ cells are a
+negative-control arm, not part of the primary H2 decision.
 
-**H3.** Mechanisms that break proportional hazards structurally — a
-non-monotone hazard, and a survival plateau from a cured fraction — produce
-larger RMISE for proportional-hazards estimators than mechanisms that only
-change the baseline's shape. The primary H3 contrast is restricted to
-$\beta>0$ and requires the complete structural and PH/baseline DGP sets at each
-matched support point.
+**H3.** Mechanisms that break proportional hazards structurally through
+non-monotone hazards produce larger RMISE for proportional-hazards estimators
+than mechanisms that only change the baseline's shape. The primary H3
+structural DGPs are `aft_ln` and `aft_log_logistic`; the PH/baseline DGPs are
+`aft_weibull` and `piecewise_exponential`; `cphm` is retained as a
+reference/validation DGP rather than pooled into the primary H3 contrast. The
+primary H3 contrast is restricted to $\beta>0$ and requires the complete
+structural and PH/baseline DGP sets at each matched support point.
+
+**H3b.** `mixture_cure` is analysed separately as a survival-plateau
+sensitivity contrast against `aft_weibull` and `piecewise_exponential` on its
+50%/70% common support, again restricted to $\beta>0$ and
+proportional-hazards estimators.
 
 **H4.** Censoring degrades absolute probability recovery more than it degrades
 ranking. Operationally, the contrast between 70% and 10% target censoring is
-larger on mean RMISE than on mean Harrell C-index after each metric is
-standardised by its across-cell standard deviation.
+larger on mean RMISE than on mean integrated-hazard Harrell C-index after each
+metric is standardised by its across-cell standard deviation. The primary H4
+contrast is restricted to $\beta>0$ and paired on common
+$(\text{DGP}, n, \beta, \text{estimator})$ support; `mixture_cure` drops out
+because it has no 10% support.
 
 These are directional statements, and the study may refute any of them. The
 pilot is consistent with H1 and H2 (see §7); that is a reason to run the
@@ -110,12 +122,13 @@ with the reason recorded: `mixture_cure` cannot reach 10% or 30% censoring
 because a 30% cure fraction puts a floor of about 31% on the censoring rate, so
 roughly 198 scenarios will run.
 
-**Replications.** $R = 500$, from inverting
+**Replications.** $R = 500$. The first sizing calculation inverted
 $\mathrm{MCSE} = s/\sqrt{R}$ on pilot variability at a target of $0.001$ on
-MISE. This covers the 90th percentile of cells. It does **not** cover the
-hardest: `aft_log_logistic` at $n = 250$ with 70% censoring needs about 5000.
-Those cells will be reported with their Monte Carlo error, and differences
-there described as indistinguishable rather than as findings.
+MISE, covering the 90th percentile of cells but not the hardest
+`aft_log_logistic` cells. Before freeze this was supplemented by a projected
+RMISE and hypothesis/headline precision audit at $R=500$. The production
+tables will report MCSEs, and differences whose Monte Carlo uncertainty is too
+large will be described as indistinguishable rather than as findings.
 
 ## 4. Primary and secondary outcomes
 
@@ -185,35 +198,42 @@ at a single threshold. $\epsilon$ is not presented as a universal constant; its
 interpretation is conditional on the loss, the mechanism, the horizon and the
 application.
 
-The headline number is the 90th percentile of RMISE conditional on bins of a
-conventional metric, primarily Harrell's C-index. This answers the operational
+The headline number is the 90th percentile of RMISE conditional on bins of the
+primary conventional metric, integrated-hazard Harrell C-index. This answers
+the operational
 question "how large can truth-error be among rows with similar conventional
 metric values?" without turning a correlation coefficient into the claim. It is
 computed over scenario-estimator cell means, and its Monte Carlo uncertainty is
-propagated from the cell MCSEs with fixed-bin parametric bootstrap draws.
+propagated from the cell MCSEs with fixed-bin parametric bootstrap draws. These
+intervals are MC-precision approximations based on independent cell-level
+normal uncertainty, not full replication-level sampling intervals preserving
+estimator pairing.
 
 The executable hypothesis analysis is `scripts/analyze_hypotheses.py`, which
 writes `results/processed/hypotheses.parquet`, `.json` and generated manuscript
 macros. H2's correctly specified reference is `cox_ph` for `cphm`,
 `aft_weibull` and `piecewise_exponential`; no exact comparator is claimed for
 `aft_ln`, `aft_log_logistic` or `mixture_cure`. H3's proportional-hazards
-estimators are `cox_ph` and `gradient_boosted`; its structural-violation DGPs
-are `aft_ln`, `aft_log_logistic` and `mixture_cure`, compared with the
-PH/baseline group `cphm`, `aft_weibull` and `piecewise_exponential` on common
-$(n,\text{censoring},\beta,\text{estimator})$ support only when all three
-structural and all three PH/baseline DGPs are present, with $\beta=0$ reserved
-as a negative-control arm. H4 is paired on common
+estimators are `cox_ph` and `gradient_boosted`; its primary structural
+violation DGPs are `aft_ln` and `aft_log_logistic`, compared with the
+PH/baseline group `aft_weibull` and `piecewise_exponential` on common
+$(n,\text{censoring},\beta,\text{estimator})$ support only when both structural
+and both PH/baseline DGPs are present, with $\beta=0$ reserved as a
+negative-control arm. H3b separately contrasts `mixture_cure` with
+`aft_weibull` and `piecewise_exponential` on its common support. H4 is paired
+on common
 $(\text{DGP},n,\beta,\text{estimator})$ support for 10% versus 70% censoring;
 `mixture_cure` drops out of that contrast because it has no 10% support.
 
 Before freezing, `scripts/check_ipcw_availability.py` must pass with a minimum
 availability rate of 0.95 among feasible scenarios. The implementation lives in
 `scripts/audit_ipcw_availability.py`, which records the scenario-level audit.
-`scripts/check_grid_convergence.py` must pass on the 10 worst
-scenario-estimator cells by the latest processed cell-level loss summary, using
-at least 10 matched replications, with
+`scripts/check_grid_convergence.py` must pass on the 10 frozen
+scenario-estimator cells listed in `protocol/grid_audit_cells.json`, using at
+least 10 matched replications, with
 $|\mathrm{RMISE}_{51}-\mathrm{RMISE}_{801}| \le 0.002$ on the
-survival-probability scale.
+survival-probability scale and
+$|C^{IH}_{51}-C^{IH}_{801}| \le 0.002$ for integrated-hazard Harrell C-index.
 
 `scripts/freeze_experiment.py` consumes those two gate artifacts before writing
 the production lock, verifies that both criteria passed, and records each
@@ -258,7 +278,8 @@ production row carries the lock hash; resumption refuses rows with a missing or
 different lock hash. If package code affecting simulation changes after the
 freeze, that is a new experiment version, not a continuation.
 
-**The freeze has not happened, and no production run has been executed.**
+**The final freeze has not happened, and no final production Monte Carlo has
+been accepted.**
 
 ## 9. Limitations to state in the paper
 

--- a/research/discrimination-not-calibration/scripts/check_grid_convergence.py
+++ b/research/discrimination-not-calibration/scripts/check_grid_convergence.py
@@ -14,6 +14,7 @@ preparation is disabled by default for speed.
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -130,6 +131,62 @@ def select_audit_cells(
     }
 
 
+def load_audit_cells(
+    study: StudyConfig, path: Path, *, expected_count: int | None = None
+) -> set[tuple[str, str]]:
+    """Load the frozen grid-audit cell list and validate it against the design."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    cells = payload.get("cells") if isinstance(payload, dict) else payload
+    if not isinstance(cells, list):
+        raise ValueError("grid audit cell file must contain a 'cells' list")
+    if expected_count is not None and len(cells) != expected_count:
+        raise ValueError(
+            f"grid audit cell file contains {len(cells)} cells; "
+            f"expected {expected_count}"
+        )
+
+    scenarios = {scenario.scenario_id: scenario for scenario in study.scenarios}
+    estimators = {estimator.estimator_id: estimator for estimator in study.estimators}
+    selected: set[tuple[str, str]] = set()
+    for index, cell in enumerate(cells, start=1):
+        if not isinstance(cell, dict):
+            raise ValueError(f"grid audit cell {index} must be an object")
+        try:
+            scenario_id = str(cell["scenario_id"])
+            estimator_id = str(cell["estimator_id"])
+        except KeyError as exc:
+            raise ValueError(f"grid audit cell {index} missing {exc.args[0]}") from exc
+        if scenario_id not in scenarios:
+            raise ValueError(
+                f"grid audit cell {index} has unknown scenario {scenario_id}"
+            )
+        if estimator_id not in estimators:
+            raise ValueError(
+                f"grid audit cell {index} has unknown estimator {estimator_id}"
+            )
+        scenario_hash = cell.get("scenario_hash")
+        if (
+            scenario_hash is not None
+            and str(scenario_hash) != scenarios[scenario_id].hash
+        ):
+            raise ValueError(
+                f"grid audit cell {index} scenario_hash mismatch for {scenario_id}"
+            )
+        estimator_hash = cell.get("estimator_hash")
+        if (
+            estimator_hash is not None
+            and str(estimator_hash) != estimators[estimator_id].hash
+        ):
+            raise ValueError(
+                f"grid audit cell {index} estimator_hash mismatch for {estimator_id}"
+            )
+        key = (scenario_id, estimator_id)
+        if key in selected:
+            raise ValueError(f"duplicate grid audit cell: {scenario_id}/{estimator_id}")
+        selected.add(key)
+    return selected
+
+
 def score_replicate_across_grids(
     prepared_by_grid: dict[int, PreparedScenario],
     estimator,
@@ -227,6 +284,11 @@ def main() -> int:
         help="summary column used with --top-cells; defaults to RMISE then MISE",
     )
     parser.add_argument(
+        "--audit-cells",
+        default=None,
+        help="JSON file containing the frozen scenario-estimator cells to audit",
+    )
+    parser.add_argument(
         "--rmise-epsilon",
         type=float,
         default=0.002,
@@ -244,6 +306,8 @@ def main() -> int:
     arguments = parser.parse_args()
 
     study = load_study(arguments.config)
+    if arguments.audit_cells is not None and arguments.top_cells is not None:
+        raise SystemExit("--audit-cells and --top-cells are mutually exclusive")
     grid_points = sorted(set(arguments.grid_points))
     if len(grid_points) < 2:
         raise SystemExit("need at least two grid sizes")
@@ -260,18 +324,25 @@ def main() -> int:
     ]
     summary_path = Path(arguments.summary) if arguments.summary is not None else None
     summary = pd.read_parquet(summary_path) if summary_path is not None else None
-    selected_cells = select_audit_cells(
-        study,
-        summary=summary,
-        top_cells=arguments.top_cells,
-        loss_column=arguments.loss_column,
+    audit_cells_path = (
+        Path(arguments.audit_cells) if arguments.audit_cells is not None else None
     )
-    if selected_cells is not None:
-        print(
-            f"auditing top {len(selected_cells)} scenario-estimator cells", flush=True
+    if audit_cells_path is not None:
+        selected_cells = load_audit_cells(study, audit_cells_path)
+    else:
+        selected_cells = select_audit_cells(
+            study,
+            summary=summary,
+            top_cells=arguments.top_cells,
+            loss_column=arguments.loss_column,
         )
+    if selected_cells is not None:
+        print(f"auditing {len(selected_cells)} scenario-estimator cells", flush=True)
 
     metadata = study_metadata(study)
+    audited_cell_count = (
+        len(selected_cells) if selected_cells is not None else arguments.top_cells or 0
+    )
     metadata.update(
         {
             "audited_replications": arguments.replications,
@@ -280,7 +351,10 @@ def main() -> int:
             "selected_summary_sha256": (
                 file_sha256(summary_path) if summary_path is not None else ""
             ),
-            "top_cells": arguments.top_cells or 0,
+            "audit_cells_sha256": (
+                file_sha256(audit_cells_path) if audit_cells_path is not None else ""
+            ),
+            "top_cells": audited_cell_count,
             "loss_column": arguments.loss_column or "",
         }
     )

--- a/research/discrimination-not-calibration/scripts/freeze_experiment.py
+++ b/research/discrimination-not-calibration/scripts/freeze_experiment.py
@@ -22,9 +22,9 @@ sys.path.insert(0, str(HERE))
 from audit_ipcw_availability import availability_passes  # noqa: E402
 from check_grid_convergence import (  # noqa: E402
     grid_convergence_passes,
+    load_audit_cells,
     maximum_c_index_difference,
     maximum_rmise_difference,
-    select_audit_cells,
 )
 from gate_artifacts import file_sha256, metadata_problems  # noqa: E402
 from survival_misspec.config import StudyConfig, load_study  # noqa: E402
@@ -117,14 +117,14 @@ def _grid_gate_evidence(
     rmise_epsilon: float,
     c_index_epsilon: float,
     study: StudyConfig,
-    summary_path: Path,
+    audit_cells_path: Path,
     top_cells: int,
     minimum_replications: int,
 ) -> dict[str, object]:
     if not path.exists():
         raise SystemExit(f"missing grid-convergence gate artifact: {path}")
-    if not summary_path.exists():
-        raise SystemExit(f"missing grid-convergence selection summary: {summary_path}")
+    if not audit_cells_path.exists():
+        raise SystemExit(f"missing frozen grid-audit cell list: {audit_cells_path}")
     frame = pd.read_parquet(path)
     if frame.empty or "reference_n_time_points" not in frame.columns:
         raise SystemExit(f"grid-convergence gate artifact is incomplete: {path}")
@@ -134,12 +134,11 @@ def _grid_gate_evidence(
         expected={
             "rmise_epsilon": rmise_epsilon,
             "c_index_epsilon": c_index_epsilon,
-            "selected_summary_sha256": file_sha256(summary_path),
+            "audit_cells_sha256": file_sha256(audit_cells_path),
             "top_cells": top_cells,
         },
     )
-    summary = pd.read_parquet(summary_path)
-    selected = select_audit_cells(study, summary=summary, top_cells=top_cells)
+    selected = load_audit_cells(study, audit_cells_path, expected_count=top_cells)
     artifact_cells = {
         (str(row.scenario_id), str(row.estimator_id))
         for row in frame[["scenario_id", "estimator_id"]].drop_duplicates().itertuples()
@@ -195,7 +194,7 @@ def _grid_gate_evidence(
         "scenario_design_hash": str(frame["scenario_design_hash"].iloc[0]),
         "estimator_design_hash": str(frame["estimator_design_hash"].iloc[0]),
         "metrics_hash": str(frame["metrics_hash"].iloc[0]),
-        "selected_summary_sha256": file_sha256(summary_path),
+        "audit_cells_sha256": file_sha256(audit_cells_path),
         "top_cells": top_cells,
         "audited_replications": minimum_replications,
         "maximum_rmise_difference": float(maximum_rmise),
@@ -228,9 +227,9 @@ def main() -> int:
     parser.add_argument("--rmise-epsilon", type=float, default=0.002)
     parser.add_argument("--c-index-epsilon", type=float, default=0.002)
     parser.add_argument(
-        "--grid-summary",
-        default=str(HERE.parent / "results" / "processed" / "summary.parquet"),
-        help="summary parquet whose worst cells selected the grid gate",
+        "--grid-audit-cells",
+        default=str(HERE.parent / "protocol" / "grid_audit_cells.json"),
+        help="frozen scenario-estimator cells selected for the grid gate",
     )
     parser.add_argument("--grid-top-cells", type=int, default=10)
     parser.add_argument("--grid-minimum-replications", type=int, default=10)
@@ -258,7 +257,7 @@ def main() -> int:
                 arguments.rmise_epsilon,
                 arguments.c_index_epsilon,
                 study,
-                Path(arguments.grid_summary),
+                Path(arguments.grid_audit_cells),
                 arguments.grid_top_cells,
                 arguments.grid_minimum_replications,
             ),

--- a/research/discrimination-not-calibration/scripts/reproduce.py
+++ b/research/discrimination-not-calibration/scripts/reproduce.py
@@ -90,13 +90,13 @@ def main() -> int:
             [
                 python,
                 "scripts/check_grid_convergence.py",
-                "--summary",
-                "results/processed/summary.parquet",
-                "--top-cells",
-                "10",
+                "--audit-cells",
+                "protocol/grid_audit_cells.json",
                 "--replications",
                 "10",
                 "--rmise-epsilon",
+                "0.002",
+                "--c-index-epsilon",
                 "0.002",
             ],
         )

--- a/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
+++ b/research/discrimination-not-calibration/tests/test_pre_freeze_gates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -191,11 +192,94 @@ def test_grid_convergence_selects_worst_cells_from_summary() -> None:
     assert selected == {("s1", "weibull_aft"), ("s2", "cox_ph")}
 
 
+def test_grid_convergence_loads_frozen_audit_cells(tmp_path) -> None:
+    grid = _load_script("check_grid_convergence.py")
+    study = StudyConfig(
+        paper_id="p",
+        master_seed=1,
+        n_replications=1,
+        scenarios=(ScenarioConfig("s1", "cphm", 100, 0.3, 0.5, {}),),
+        estimators=(EstimatorConfig("cox_ph", "cox_ph"),),
+        metrics=MetricsConfig(0.8, 11, (0.5,), ("mise",)),
+    )
+    path = tmp_path / "grid_audit_cells.json"
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "scenario_id": "s1",
+                        "scenario_hash": study.scenarios[0].hash,
+                        "estimator_id": "cox_ph",
+                        "estimator_hash": study.estimators[0].hash,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    selected = grid.load_audit_cells(study, path, expected_count=1)
+
+    assert selected == {("s1", "cox_ph")}
+
+
+def test_grid_convergence_rejects_stale_frozen_audit_cells(tmp_path) -> None:
+    grid = _load_script("check_grid_convergence.py")
+    study = StudyConfig(
+        paper_id="p",
+        master_seed=1,
+        n_replications=1,
+        scenarios=(ScenarioConfig("s1", "cphm", 100, 0.3, 0.5, {}),),
+        estimators=(EstimatorConfig("cox_ph", "cox_ph"),),
+        metrics=MetricsConfig(0.8, 11, (0.5,), ("mise",)),
+    )
+    path = tmp_path / "grid_audit_cells.json"
+    path.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "scenario_id": "s1",
+                        "scenario_hash": "stale",
+                        "estimator_id": "cox_ph",
+                        "estimator_hash": study.estimators[0].hash,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="scenario_hash mismatch"):
+        grid.load_audit_cells(study, path, expected_count=1)
+
+
+def test_grid_convergence_requires_exact_frozen_cell_count(tmp_path) -> None:
+    grid = _load_script("check_grid_convergence.py")
+    study = StudyConfig(
+        paper_id="p",
+        master_seed=1,
+        n_replications=1,
+        scenarios=(ScenarioConfig("s1", "cphm", 100, 0.3, 0.5, {}),),
+        estimators=(EstimatorConfig("cox_ph", "cox_ph"),),
+        metrics=MetricsConfig(0.8, 11, (0.5,), ("mise",)),
+    )
+    path = tmp_path / "grid_audit_cells.json"
+    path.write_text(
+        json.dumps({"cells": [{"scenario_id": "s1", "estimator_id": "cox_ph"}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="contains 1 cells; expected 2"):
+        grid.load_audit_cells(study, path, expected_count=2)
+
+
 def test_freeze_gate_evidence_records_passed_artifact_hashes(tmp_path) -> None:
     freeze = _load_script("freeze_experiment.py")
     ipcw = tmp_path / "ipcw.parquet"
     grid = tmp_path / "grid.parquet"
-    summary = tmp_path / "summary.parquet"
+    audit_cells = tmp_path / "grid_audit_cells.json"
     study = StudyConfig(
         paper_id="p",
         master_seed=1,
@@ -232,19 +316,27 @@ def test_freeze_gate_evidence_records_passed_artifact_hashes(tmp_path) -> None:
             },
         ]
     ).to_parquet(ipcw, index=False)
-    pd.DataFrame(
-        {
-            "scenario_id": ["s1", "s2"],
-            "estimator_id": ["cox_ph", "cox_ph"],
-            "root_mean_integrated_squared_error_mean": [0.9, 0.1],
-        }
-    ).to_parquet(summary, index=False)
+    audit_cells.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "scenario_id": "s1",
+                        "scenario_hash": study.scenarios[0].hash,
+                        "estimator_id": "cox_ph",
+                        "estimator_hash": study.estimators[0].hash,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     grid_metadata = _metadata(
         study,
         audited_replications=10,
         rmise_epsilon=0.002,
         c_index_epsilon=0.002,
-        selected_summary_sha256=freeze.file_sha256(summary),
+        audit_cells_sha256=freeze.file_sha256(audit_cells),
         top_cells=1,
         loss_column="",
     )
@@ -271,7 +363,7 @@ def test_freeze_gate_evidence_records_passed_artifact_hashes(tmp_path) -> None:
 
     ipcw_evidence = freeze._ipcw_gate_evidence(ipcw, 0.95, study)
     grid_evidence = freeze._grid_gate_evidence(
-        grid, 0.002, 0.002, study, summary, 1, 10
+        grid, 0.002, 0.002, study, audit_cells, 1, 10
     )
 
     assert ipcw_evidence["status"] == "PASS"


### PR DESCRIPTION
## Summary
- add committed protocol/grid_audit_cells.json with the exact pre-freeze grid-convergence cells and design hashes
- make check_grid_convergence.py accept the frozen audit-cell file and make freeze_experiment.py validate gate artifacts against it
- synchronize preregistration/README/reproduce docs with H3/H3b, beta-positive contrasts, integrated-hazard Harrell C-index, both grid thresholds, and the R=500 precision-audit language

## Validation
- poetry run pre-commit run --all-files
- poetry run pytest research\\discrimination-not-calibration\\tests\\test_pre_freeze_gates.py research\\discrimination-not-calibration\\tests\\test_hypotheses.py -q
- poetry run pytest
- poetry run mkdocs build --strict

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes the grid-convergence audit cell selection so the pre-production gate can no longer drift after freeze.

- Commits `protocol/grid_audit_cells.json` with the 10 pre-freeze scenario-estimator cells and their design hashes.
- `check_grid_convergence.py` now reads `--audit-cells` from that file and rejects stale or duplicate cells; `--top-cells` selection from the summary remains available.
- `freeze_experiment.py` validates grid gate artifacts against the frozen cell list and records the file's SHA-256 instead of the summary's.
- Updates `preregistration.md`, `README.md`, and `reproduce.py` to the H3/H3b contrasts, beta-positive primary analyses, integrated-hazard Harrell C-index, and the C-index epsilon threshold.

<sup>Written for commit f6645ec2148d7005abacc003a324434aaca31baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

