### PR TITLE
Report uncertainty in failure table

### DIFF
--- a/research/discrimination-not-calibration/scripts/make_tables.py
+++ b/research/discrimination-not-calibration/scripts/make_tables.py
@@ -288,6 +288,9 @@ def table_failures(failures: pd.DataFrame, out: Path) -> None:
         .reset_index()
     )
     grouped["rate"] = grouped["fit_failures"] / grouped["attempted"]
+    grouped["rate_se"] = (
+        grouped["rate"] * (1.0 - grouped["rate"]) / grouped["attempted"]
+    ).map(math.sqrt)
     intervals = [
         _wilson_interval(int(row.fit_failures), int(row.attempted))
         for row in grouped.itertuples()
@@ -304,14 +307,15 @@ def table_failures(failures: pd.DataFrame, out: Path) -> None:
         r"\label{tab:failures}",
         r"\begin{tabular}{lrrrr}",
         r"\toprule",
-        r"Estimator & Attempted & Fit failures & Scoring failures & Rate (95\% CI) \\",
+        r"Estimator & Attempted & Fit failures & Scoring failures & Rate (SE; 95\% CI) \\",
         r"\midrule",
     ]
     for row in grouped.itertuples():
         body.append(
             f"\\texttt{{{_escape(str(row.estimator_id))}}} & {int(row.attempted)} & "
             f"{int(row.fit_failures)} & {int(row.score_failures)} & "
-            f"{row.rate:.4f} [{row.rate_low:.4f}, {row.rate_high:.4f}] \\\\"
+            f"{row.rate:.4f} \\;({row.rate_se:.4f}) "
+            f"[{row.rate_low:.4f}, {row.rate_high:.4f}] \\\\"
         )
     body += [r"\bottomrule", r"\end{tabular}", r"\end{table}", ""]
     _write(


### PR DESCRIPTION
## Summary
- include binomial standard errors in the generated failure-rate table
- keep the Wilson interval while matching the table uncertainty policy

## Validation
- poetry run pre-commit run --all-files
- poetry run pytest research/discrimination-not-calibration/tests -q
- poetry run mkdocs build --strict

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports uncertainty in the failure-rate table by adding binomial standard errors next to the existing Wilson confidence intervals.

<sup>Written for commit 61c83c90e76d1cf6a38a1930a922926277649e03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/genSurvPy/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

